### PR TITLE
Support for analytic versions

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -37,14 +37,17 @@ class JobExecutionError extends utils.ExtendableError {}
  */
 class JobRequest extends utils.Serializable {
   /**
-   * Creates a new JobRequest instance.
+   * Creates a JobRequest instance.
    *
    * @constructor
    * @param {string} analytic - the name of the analytic to run
+   * @param {string} [version=null] - the version of the analytic to run.
+   *   If not specified, the latest available version is used
    */
-  constructor(analytic) {
+  constructor(analytic, version = null) {
     super();
     this.analytic = analytic;
+    this.version = version;
     this.inputs = {};
     this.parameters = {};
   }

--- a/lib/query.js
+++ b/lib/query.js
@@ -201,7 +201,7 @@ class AnalyticsQuery extends BaseQuery {
  */
 class DataQuery extends BaseQuery {
   /**
-   * Creates a new DataQuery instance.
+   * Creates a DataQuery instance.
    *
    * @constructor
    */

--- a/lib/query.js
+++ b/lib/query.js
@@ -175,6 +175,19 @@ class AnalyticsQuery extends BaseQuery {
    */
   constructor() {
     super(['id', 'name', 'version', 'upload_date', 'description']);
+    this.all_versions = false;
+  }
+
+  /**
+   * Sets the `all_versions` parameter of the query
+   *
+   * @param {boolean} allVersions - whether to include all versions of each
+   *   analytic in the query
+   * @returns {BaseQuery} the updated query instance
+   */
+  setAllVersions(allVersions) {
+    this.all_versions = allVersions;
+    return this;
   }
 }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -222,14 +222,14 @@ class DataQuery extends BaseQuery {
  */
 class JobsQuery extends BaseQuery {
   /**
-   * Creates a new JobsQuery instance.
+   * Creates a JobsQuery instance.
    *
    * @constructor
    */
   constructor() {
     super([
       'id', 'name', 'state', 'archived', 'upload_date', 'analytic_id',
-      'auto_start', 'use_gpu']);
+      'analytic_version', 'auto_start', 'use_gpu']);
   }
 }
 


### PR DESCRIPTION
Delivers the following two stories:
https://www.pivotaltracker.com/story/show/163953187
https://www.pivotaltracker.com/story/show/163889923

Note that I also took the liberty of adding `analytic_version` as a supported field for job queries. I requested that this is implemented server-side in the following story:
https://www.pivotaltracker.com/story/show/164131068