### PR TITLE
Adding analytics routes for applications

### DIFF
--- a/lib/apps/api.js
+++ b/lib/apps/api.js
@@ -77,7 +77,60 @@ class ApplicationAPI extends API {
     return new ApplicationAPI(token);
   }
 
+  //
   // ANALYTICS
+  //
+  // Note that all analytic methods override the inherited methods from API,
+  // because analytic listing has different behavior for applications than it
+  // does for individual platform users.
+  //
+
+  /**
+   * Returns a list of all available analytics.
+   *
+   * @async
+   * @param {boolean} [allVersions=false] - whether to return all versions of
+   *   each analytic or only the latest version
+   * @returns {Array} an array of objects describing the analytics
+   * @throws {APIError} if the request was unsuccessful
+   */
+  async listAnalytics(allVersions = false) {
+    let uri = this.baseURL + '/apps/analytics/list';
+    let params = {all_versions: allVersions};
+    let body = await requests.get(uri, this.header_, {qs: params});
+    return JSON.parse(body).analytics;
+  }
+
+  /**
+   * Performs a customized analytics query.
+   *
+   * @async
+   * @param {AnalyticsQuery} analyticsQuery An AnalyticsQuery instance defining
+   *   the customized analytics query to perform
+   * @returns {object} an object containing the query results and total number
+   *   of records
+   * @throws {APIError} if the request was unsuccessful
+   */
+  async queryAnalytics(analyticsQuery) {
+    let uri = this.baseURL + '/apps/analytics';
+    let body = await requests.get(
+      uri, this.header_, {qs: analyticsQuery.toObject()});
+    return JSON.parse(body);
+  }
+
+  /**
+   * Gets documentation about the analytic with the given ID.
+   *
+   * @async
+   * @param {string} analyticId - the analytic ID
+   * @returns {object} an object containing the analytic documentation
+   * @throws {APIError} if the request was unsuccessful
+   */
+  async getAnalyticDoc(analyticId) {
+    let uri = this.baseURL + '/apps/analytics/' + analyticId;
+    let body = await requests.get(uri, this.header_);
+    return JSON.parse(body);
+  }
 
   /**
    * Uploads the analytic documentation JSON file that describes a new private


### PR DESCRIPTION
Think of this as documentation-driven development. Goal is to have API routes that serve the promised functionality here.