### PR TITLE
Adding autoBind to solve class binding problems

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -9,12 +9,13 @@
 
 'use strict';
 
-let fs = require('fs');
+const autoBind = require('auto-bind');
+const fs = require('fs');
 
-let auth = require('./auth.js');
-let jobs = require('./jobs.js');
-let requests = require('./requests.js');
-let utils = require('./utils.js');
+const auth = require('./auth.js');
+const jobs = require('./jobs.js');
+const requests = require('./requests.js');
+const utils = require('./utils.js');
 
 const BASE_URL = 'https://api.voxel51.com/v1';
 
@@ -36,6 +37,7 @@ class API {
     this.baseURL = BASE_URL;
     this.token = token || auth.loadToken();
     this.header_ = this.token.getHeader();
+    autoBind(this);
   }
 
   /**

--- a/lib/apps/api.js
+++ b/lib/apps/api.js
@@ -9,11 +9,12 @@
 
 'use strict';
 
-let fs = require('fs');
+const autoBind = require('auto-bind');
+const fs = require('fs');
 
-let API = require('../api.js');
-let auth = require('./auth.js');
-let utils = require('../utils.js');
+const API = require('../api.js');
+const auth = require('./auth.js');
+const utils = require('../utils.js');
 
 /**
  * Main class for managing an application session with the Voxel51 Vision
@@ -40,6 +41,7 @@ class ApplicationAPI extends API {
     token = token || auth.loadToken();
     super(token);
     this.activeUser = null;
+    autoBind(this);
   }
 
   /**

--- a/lib/apps/auth.js
+++ b/lib/apps/auth.js
@@ -9,12 +9,13 @@
 
 'use strict';
 
-let fs = require('fs');
-let os = require('os');
-let path = require('path');
+const autoBind = require('auto-bind');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
-let auth = require('../auth.js');
-let utils = require('../utils.js');
+const auth = require('../auth.js');
+const utils = require('../utils.js');
 
 const TOKEN_ENVIRON_VAR = 'VOXEL51_APP_TOKEN';
 const KEY_HEADER = 'x-voxel51-application';
@@ -70,6 +71,18 @@ function loadApplicationToken(tokenPath = null) {
  * @extends module:auth~Token
  */
 class ApplicationToken extends auth.Token {
+
+  /**
+   * Creates a new ApplicationToken object with the given contents.
+   *
+   * @constructor
+   * @param {object} token - an object defining an application API token
+   * @retuns {ApplicationToken} an ApplicationToken instance
+   */
+  constructor(token_obj) {
+    super(token_obj);
+    autoBind(this);
+  }
 
   /**
    * Returns a header dictionary for authenticating requests with this

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,11 +9,12 @@
 
 'use strict';
 
-let fs = require('fs');
-let os = require('os');
-let path = require('path');
+const autoBind = require('auto-bind');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
-let utils = require('./utils.js');
+const utils = require('./utils.js');
 
 const TOKEN_ENVIRON_VAR = 'VOXEL51_API_TOKEN';
 const TOKEN_PATH = path.join(os.homedir(), '.voxel51', 'api-token.json');
@@ -77,6 +78,7 @@ class Token {
   constructor(token_obj) {
     this.token_obj_ = token_obj;
     this.private_key_ = token_obj[ACCESS_TOKEN_FIELD][PRIVATE_KEY_FIELD];
+    autoBind(this);
   }
 
   /**

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -10,7 +10,9 @@
 
 'use strict';
 
-let utils = require('./utils.js');
+const autoBind = require('auto-bind');
+
+const utils = require('./utils.js');
 
 const DATA_ID_FIELD = 'data-id';
 
@@ -52,6 +54,7 @@ class JobRequest extends utils.Serializable {
     this.version = version;
     this.inputs = {};
     this.parameters = {};
+    autoBind(this);
   }
 
   /**
@@ -146,6 +149,7 @@ class RemoteDataPath extends utils.Serializable {
     if (!this.isValid) {
         throw new RemoteDataPathError('Invalid RemoteDataPath')
     }
+    autoBind(this);
   }
 
   get hasDataId() {

--- a/lib/query.js
+++ b/lib/query.js
@@ -9,7 +9,8 @@
 
 'use strict';
 
-let qs = require('qs');
+const autoBind = require('auto-bind');
+const qs = require('qs');
 
 /**
  * Base class for API queries.
@@ -32,6 +33,7 @@ class BaseQuery {
     this.sort = null;
     this.offset = null;
     this.limit = null;
+    autoBind(this);
   }
 
   /**
@@ -180,6 +182,7 @@ class AnalyticsQuery extends BaseQuery {
       'id', 'name', 'version', 'upload_date', 'description', 'scope',
       'supports_cpu', 'supports_gpu', 'pending']);
     this.all_versions = false;
+    autoBind(this);
   }
 
   /**
@@ -214,6 +217,7 @@ class DataQuery extends BaseQuery {
     super([
       'id', 'name', 'encoding', 'type', 'size', 'upload_date',
       'expiration_date']);
+    autoBind(this);
   }
 }
 
@@ -236,6 +240,7 @@ class JobsQuery extends BaseQuery {
     super([
       'id', 'name', 'state', 'archived', 'upload_date', 'analytic_id',
       'auto_start', 'use_gpu', 'start_date', 'completion_date', 'fail_date']);
+    autoBind(this);
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,9 +9,9 @@
 
 'use strict';
 
-let fs = require('fs');
-let mkdirp = require('mkdirp');
-let path = require('path');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const path = require('path');
 
 /**
  * Reads JSON from file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,35 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@sinonjs/commons": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+            "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
         "@sinonjs/formatio": {
             "version": "2.0.0",
             "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -13,63 +42,74 @@
                 "samsam": "1.3.0"
             }
         },
-        "acorn": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-            "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-            "dev": true
-        },
-        "acorn-jsx": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+        "@sinonjs/samsam": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+            "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
             "dev": true,
             "requires": {
-                "acorn": "3.3.0"
+                "@sinonjs/commons": "^1.0.2",
+                "array-from": "^2.1.1",
+                "lodash": "^4.17.11"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
                     "dev": true
                 }
             }
+        },
+        "@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
+        "acorn": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+            "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+            "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+            "dev": true
         },
         "ajv": {
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
-        "ajv-keywords": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-            "dev": true
-        },
         "ansi-escapes": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
             "dev": true
         },
         "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
             "dev": true
         },
         "ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
         },
         "argparse": {
             "version": "1.0.10",
@@ -77,17 +117,14 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
-        "array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
-            "requires": {
-                "array-uniq": "1.0.3"
-            }
+        "array-from": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+            "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+            "dev": true
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -95,18 +132,12 @@
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
             "dev": true
         },
-        "arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-            "dev": true
-        },
         "asn1": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "assert-plus": {
@@ -120,10 +151,21 @@
             "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true
         },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "auto-bind": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-2.0.0.tgz",
+            "integrity": "sha512-rvRBv0/O7iriUMqSzTDhAfyAD1vVnElAEruo5rMSFeYLA0iKDEzLPSJiwMnL86+IPpTlhfOIAzjoKZ9TaySYdA=="
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -134,41 +176,6 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-        },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                }
-            }
         },
         "babylon": {
             "version": "7.0.0-beta.19",
@@ -188,7 +195,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "bluebird": {
@@ -203,7 +210,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -213,25 +220,10 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
-        "buffer-from": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-            "dev": true
-        },
-        "caller-path": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-            "dev": true,
-            "requires": {
-                "callsites": "0.2.0"
-            }
-        },
         "callsites": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+            "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
             "dev": true
         },
         "caseless": {
@@ -245,7 +237,7 @@
             "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
             "dev": true,
             "requires": {
-                "underscore-contrib": "0.3.0"
+                "underscore-contrib": "~0.3.0"
             }
         },
         "chai": {
@@ -254,12 +246,12 @@
             "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
             "dev": true,
             "requires": {
-                "assertion-error": "1.1.0",
-                "check-error": "1.0.2",
-                "deep-eql": "3.0.1",
-                "get-func-name": "2.0.0",
-                "pathval": "1.1.0",
-                "type-detect": "4.0.8"
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
             }
         },
         "chalk": {
@@ -268,9 +260,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -279,7 +271,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "supports-color": {
@@ -288,15 +280,15 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
         },
         "chardet": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
             "dev": true
         },
         "check-error": {
@@ -305,19 +297,13 @@
             "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
             "dev": true
         },
-        "circular-json": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-            "dev": true
-        },
         "cli-cursor": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-width": {
@@ -337,7 +323,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -351,7 +337,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -366,32 +352,22 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
-        "concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
-            }
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.2",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "dashdash": {
@@ -399,7 +375,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "debug": {
@@ -408,7 +384,7 @@
             "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
             "dev": true,
             "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
             }
         },
         "deep-eql": {
@@ -417,7 +393,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "4.0.8"
+                "type-detect": "^4.0.0"
             }
         },
         "deep-is": {
@@ -425,21 +401,6 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
-        },
-        "del": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-            "dev": true,
-            "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
-            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -453,12 +414,12 @@
             "dev": true
         },
         "doctrine": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "dom-serializer": {
@@ -467,8 +428,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -491,7 +452,7 @@
             "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -500,8 +461,8 @@
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "ecc-jsbn": {
@@ -510,9 +471,15 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
         },
         "entities": {
             "version": "1.1.1",
@@ -527,49 +494,82 @@
             "dev": true
         },
         "eslint": {
-            "version": "4.19.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-            "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+            "version": "5.15.3",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
+            "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.4.1",
-                "concat-stream": "1.6.2",
-                "cross-spawn": "5.1.0",
-                "debug": "3.2.6",
-                "doctrine": "2.1.0",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0",
-                "espree": "3.5.4",
-                "esquery": "1.0.1",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "11.5.0",
-                "ignore": "3.3.8",
-                "imurmurhash": "0.1.4",
-                "inquirer": "3.3.0",
-                "is-resolvable": "1.1.0",
-                "js-yaml": "3.11.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "regexpp": "1.1.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.5.0",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
-                "table": "4.0.2",
-                "text-table": "0.2.0"
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.9.1",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "eslint-scope": "^4.0.3",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^5.0.1",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^5.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.2.2",
+                "js-yaml": "^3.12.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.11",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.1",
+                "semver": "^5.5.1",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^5.2.3",
+                "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.10.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+                    "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                }
             }
         },
         "eslint-config-google": {
@@ -579,14 +579,20 @@
             "dev": true
         },
         "eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+            "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
+        },
+        "eslint-utils": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+            "dev": true
         },
         "eslint-visitor-keys": {
             "version": "1.0.0",
@@ -595,19 +601,20 @@
             "dev": true
         },
         "espree": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-            "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+            "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "acorn-jsx": "3.0.1"
+                "acorn": "^6.0.7",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
             }
         },
         "esprima": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
         },
         "esquery": {
@@ -616,7 +623,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -625,7 +632,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -646,14 +653,14 @@
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "external-editor": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-            "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+            "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
             "dev": true,
             "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.22",
-                "tmp": "0.0.33"
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
             }
         },
         "extsprintf": {
@@ -683,30 +690,34 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+            "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^2.0.1"
             }
         },
         "flat-cache": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-            "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "flatted": "^2.0.0",
+                "rimraf": "2.6.3",
+                "write": "1.0.3"
             }
+        },
+        "flatted": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+            "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+            "dev": true
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -718,9 +729,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.20"
+                "mime-types": "^2.1.12"
             },
             "dependencies": {
                 "combined-stream": {
@@ -728,7 +739,7 @@
                     "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
                     "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 }
             }
@@ -756,7 +767,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -765,33 +776,19 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "globals": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-            "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+            "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
             "dev": true
-        },
-        "globby": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-            "dev": true,
-            "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-            }
         },
         "graceful-fs": {
             "version": "4.1.11",
@@ -815,17 +812,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
             "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-            }
-        },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "2.1.1"
+                "ajv": "^5.3.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has-flag": {
@@ -846,12 +834,12 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.1",
-                "domutils": "1.7.0",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "http-signature": {
@@ -859,25 +847,35 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "iconv-lite": {
-            "version": "0.4.22",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.22.tgz",
-            "integrity": "sha512-1AinFBeDTnsvVEP+V1QBlHpM1UZZl7gWB6fcz7B1Ho+LI1dUh2sSrxoCfVt2PinRHzXAziSniEV3P7JbTDHcXA==",
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ignore": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-            "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true
+        },
+        "import-fresh": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+            "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            }
         },
         "imurmurhash": {
             "version": "0.1.4",
@@ -891,8 +889,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -907,30 +905,57 @@
             "integrity": "sha512-STx5orGQU1gfrkoI/fMU7lX6CSP7LBGO10gXNgOZhwKhUqbtNjCkYSewJtNnLmWP1tAGN6oyEpG1HFPw5vpa5Q==",
             "dev": true,
             "requires": {
-                "moment": "2.22.1",
-                "sanitize-html": "1.18.2"
+                "moment": "^2.14.1",
+                "sanitize-html": "^1.13.0"
             }
         },
         "inquirer": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-            "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+            "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.2.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.10",
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.11",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rxjs": "^6.4.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^5.0.0",
+                "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
         },
         "is-fullwidth-code-point": {
@@ -939,40 +964,10 @@
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
         },
-        "is-path-cwd": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-            "dev": true
-        },
-        "is-path-in-cwd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-            "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-            "dev": true,
-            "requires": {
-                "is-path-inside": "1.0.1"
-            }
-        },
-        "is-path-inside": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-            "dev": true,
-            "requires": {
-                "path-is-inside": "1.0.2"
-            }
-        },
         "is-promise": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-            "dev": true
-        },
-        "is-resolvable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
             "dev": true
         },
         "is-typedarray": {
@@ -998,19 +993,19 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
         "js-yaml": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+            "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "js2xmlparser": {
@@ -1019,7 +1014,7 @@
             "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
             "dev": true,
             "requires": {
-                "xmlcreate": "1.0.2"
+                "xmlcreate": "^1.0.1"
             }
         },
         "jsbn": {
@@ -1035,21 +1030,22 @@
             "dev": true,
             "requires": {
                 "babylon": "7.0.0-beta.19",
-                "bluebird": "3.5.1",
-                "catharsis": "0.8.9",
-                "escape-string-regexp": "1.0.5",
-                "js2xmlparser": "3.0.0",
-                "klaw": "2.0.0",
-                "marked": "0.3.19",
-                "mkdirp": "0.5.1",
-                "requizzle": "0.2.1",
-                "strip-json-comments": "2.0.1",
+                "bluebird": "~3.5.0",
+                "catharsis": "~0.8.9",
+                "escape-string-regexp": "~1.0.5",
+                "js2xmlparser": "~3.0.0",
+                "klaw": "~2.0.0",
+                "marked": "~0.3.6",
+                "mkdirp": "~0.5.1",
+                "requizzle": "~0.2.1",
+                "strip-json-comments": "~2.0.1",
                 "taffydb": "2.6.2",
-                "underscore": "1.8.3"
+                "underscore": "~1.8.3"
             }
         },
         "jsdoc-template": {
-            "version": "git://github.com/braintree/jsdoc-template.git#ec0e3c0ec95de6b4e928af3285bbf69aac2f25b6"
+            "version": "git://github.com/braintree/jsdoc-template.git#ec0e3c0ec95de6b4e928af3285bbf69aac2f25b6",
+            "from": "git://github.com/braintree/jsdoc-template.git"
         },
         "json-schema": {
             "version": "0.2.3",
@@ -1084,9 +1080,9 @@
             }
         },
         "just-extend": {
-            "version": "1.1.27",
-            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-            "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+            "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
             "dev": true
         },
         "klaw": {
@@ -1095,7 +1091,7 @@
             "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.9"
             }
         },
         "levn": {
@@ -1104,14 +1100,14 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "lodash": {
-            "version": "4.17.10",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
         "lodash.clonedeep": {
@@ -1156,16 +1152,6 @@
             "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
             "dev": true
         },
-        "lru-cache": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-            "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-            "dev": true,
-            "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-            }
-        },
         "marked": {
             "version": "0.3.19",
             "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
@@ -1182,7 +1168,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
             "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
             "requires": {
-                "mime-db": "1.36.0"
+                "mime-db": "~1.36.0"
             }
         },
         "mimic-fn": {
@@ -1197,7 +1183,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -1253,7 +1239,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -1282,17 +1268,35 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
         "nise": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
-            "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+            "version": "1.4.10",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+            "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
             "dev": true,
             "requires": {
-                "@sinonjs/formatio": "2.0.0",
-                "just-extend": "1.1.27",
-                "lolex": "2.3.2",
-                "path-to-regexp": "1.7.0",
-                "text-encoding": "0.6.4"
+                "@sinonjs/formatio": "^3.1.0",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "lolex": "^2.3.2",
+                "path-to-regexp": "^1.7.0"
+            },
+            "dependencies": {
+                "@sinonjs/formatio": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+                    "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^1",
+                        "@sinonjs/samsam": "^3.1.0"
+                    }
+                }
             }
         },
         "npm": {
@@ -1300,136 +1304,136 @@
             "resolved": "https://registry.npmjs.org/npm/-/npm-6.8.0.tgz",
             "integrity": "sha512-xMH6V0OCSJ5ZET6yWPI3BmJSqMMCuVJSIcLx3LSH/SrratFSt6EDuCuGRFMQYty98Q1l6x/7vKmfURosoyWgrA==",
             "requires": {
-                "JSONStream": "1.3.5",
-                "abbrev": "1.1.1",
-                "ansicolors": "0.3.2",
-                "ansistyles": "0.1.3",
-                "aproba": "2.0.0",
-                "archy": "1.0.0",
-                "bin-links": "1.1.2",
-                "bluebird": "3.5.3",
-                "byte-size": "5.0.1",
-                "cacache": "11.3.2",
-                "call-limit": "1.1.0",
-                "chownr": "1.1.1",
-                "ci-info": "2.0.0",
-                "cli-columns": "3.1.2",
-                "cli-table3": "0.5.1",
-                "cmd-shim": "2.0.2",
-                "columnify": "1.5.4",
-                "config-chain": "1.1.12",
-                "debuglog": "1.0.1",
-                "detect-indent": "5.0.0",
-                "detect-newline": "2.1.0",
-                "dezalgo": "1.0.3",
-                "editor": "1.0.0",
-                "figgy-pudding": "3.5.1",
-                "find-npm-prefix": "1.0.2",
-                "fs-vacuum": "1.2.10",
-                "fs-write-stream-atomic": "1.0.10",
-                "gentle-fs": "2.0.1",
-                "glob": "7.1.3",
-                "graceful-fs": "4.1.15",
-                "has-unicode": "2.0.1",
-                "hosted-git-info": "2.7.1",
-                "iferr": "1.0.2",
-                "imurmurhash": "0.1.4",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "ini": "1.3.5",
-                "init-package-json": "1.10.3",
-                "is-cidr": "3.0.0",
-                "json-parse-better-errors": "1.0.2",
-                "lazy-property": "1.0.0",
-                "libcipm": "3.0.3",
-                "libnpm": "2.0.1",
-                "libnpmaccess": "3.0.1",
-                "libnpmhook": "5.0.2",
-                "libnpmorg": "1.0.0",
-                "libnpmsearch": "2.0.0",
-                "libnpmteam": "1.0.1",
-                "libnpx": "10.2.0",
-                "lock-verify": "2.0.2",
-                "lockfile": "1.0.4",
-                "lodash._baseindexof": "3.1.0",
-                "lodash._baseuniq": "4.6.0",
-                "lodash._bindcallback": "3.0.1",
-                "lodash._cacheindexof": "3.0.2",
-                "lodash._createcache": "3.1.2",
-                "lodash._getnative": "3.9.1",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.restparam": "3.6.1",
-                "lodash.union": "4.6.0",
-                "lodash.uniq": "4.5.0",
-                "lodash.without": "4.4.0",
-                "lru-cache": "4.1.5",
-                "meant": "1.0.1",
-                "mississippi": "3.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "node-gyp": "3.8.0",
-                "nopt": "4.0.1",
-                "normalize-package-data": "2.5.0",
-                "npm-audit-report": "1.3.2",
-                "npm-cache-filename": "1.0.2",
-                "npm-install-checks": "3.0.0",
-                "npm-lifecycle": "2.1.0",
-                "npm-package-arg": "6.1.0",
-                "npm-packlist": "1.3.0",
-                "npm-pick-manifest": "2.2.3",
-                "npm-profile": "4.0.1",
-                "npm-registry-fetch": "3.9.0",
-                "npm-user-validate": "1.0.0",
-                "npmlog": "4.1.2",
-                "once": "1.4.0",
-                "opener": "1.5.1",
-                "osenv": "0.1.5",
-                "pacote": "9.4.1",
-                "path-is-inside": "1.0.2",
-                "promise-inflight": "1.0.1",
-                "qrcode-terminal": "0.12.0",
-                "query-string": "6.2.0",
-                "qw": "1.0.1",
-                "read": "1.0.7",
-                "read-cmd-shim": "1.0.1",
-                "read-installed": "4.0.3",
-                "read-package-json": "2.0.13",
-                "read-package-tree": "5.2.2",
-                "readable-stream": "3.1.1",
-                "readdir-scoped-modules": "1.0.2",
-                "request": "2.88.0",
-                "retry": "0.12.0",
-                "rimraf": "2.6.3",
-                "safe-buffer": "5.1.2",
-                "semver": "5.6.0",
-                "sha": "2.0.1",
-                "slide": "1.1.6",
-                "sorted-object": "2.0.1",
-                "sorted-union-stream": "2.1.3",
-                "ssri": "6.0.1",
-                "stringify-package": "1.0.0",
-                "tar": "4.4.8",
-                "text-table": "0.2.0",
-                "tiny-relative-date": "1.3.0",
+                "JSONStream": "^1.3.5",
+                "abbrev": "~1.1.1",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "aproba": "^2.0.0",
+                "archy": "~1.0.0",
+                "bin-links": "^1.1.2",
+                "bluebird": "^3.5.3",
+                "byte-size": "^5.0.1",
+                "cacache": "^11.3.2",
+                "call-limit": "~1.1.0",
+                "chownr": "^1.1.1",
+                "ci-info": "^2.0.0",
+                "cli-columns": "^3.1.2",
+                "cli-table3": "^0.5.1",
+                "cmd-shim": "~2.0.2",
+                "columnify": "~1.5.4",
+                "config-chain": "^1.1.12",
+                "debuglog": "*",
+                "detect-indent": "~5.0.0",
+                "detect-newline": "^2.1.0",
+                "dezalgo": "~1.0.3",
+                "editor": "~1.0.0",
+                "figgy-pudding": "^3.5.1",
+                "find-npm-prefix": "^1.0.2",
+                "fs-vacuum": "~1.2.10",
+                "fs-write-stream-atomic": "~1.0.10",
+                "gentle-fs": "^2.0.1",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.1.15",
+                "has-unicode": "~2.0.1",
+                "hosted-git-info": "^2.7.1",
+                "iferr": "^1.0.2",
+                "imurmurhash": "*",
+                "inflight": "~1.0.6",
+                "inherits": "~2.0.3",
+                "ini": "^1.3.5",
+                "init-package-json": "^1.10.3",
+                "is-cidr": "^3.0.0",
+                "json-parse-better-errors": "^1.0.2",
+                "lazy-property": "~1.0.0",
+                "libcipm": "^3.0.3",
+                "libnpm": "^2.0.1",
+                "libnpmaccess": "*",
+                "libnpmhook": "^5.0.2",
+                "libnpmorg": "*",
+                "libnpmsearch": "*",
+                "libnpmteam": "*",
+                "libnpx": "^10.2.0",
+                "lock-verify": "^2.0.2",
+                "lockfile": "^1.0.4",
+                "lodash._baseindexof": "*",
+                "lodash._baseuniq": "~4.6.0",
+                "lodash._bindcallback": "*",
+                "lodash._cacheindexof": "*",
+                "lodash._createcache": "*",
+                "lodash._getnative": "*",
+                "lodash.clonedeep": "~4.5.0",
+                "lodash.restparam": "*",
+                "lodash.union": "~4.6.0",
+                "lodash.uniq": "~4.5.0",
+                "lodash.without": "~4.4.0",
+                "lru-cache": "^4.1.5",
+                "meant": "~1.0.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "~0.5.1",
+                "move-concurrently": "^1.0.1",
+                "node-gyp": "^3.8.0",
+                "nopt": "~4.0.1",
+                "normalize-package-data": "^2.5.0",
+                "npm-audit-report": "^1.3.2",
+                "npm-cache-filename": "~1.0.2",
+                "npm-install-checks": "~3.0.0",
+                "npm-lifecycle": "^2.1.0",
+                "npm-package-arg": "^6.1.0",
+                "npm-packlist": "^1.3.0",
+                "npm-pick-manifest": "^2.2.3",
+                "npm-profile": "*",
+                "npm-registry-fetch": "^3.9.0",
+                "npm-user-validate": "~1.0.0",
+                "npmlog": "~4.1.2",
+                "once": "~1.4.0",
+                "opener": "^1.5.1",
+                "osenv": "^0.1.5",
+                "pacote": "^9.4.1",
+                "path-is-inside": "~1.0.2",
+                "promise-inflight": "~1.0.1",
+                "qrcode-terminal": "^0.12.0",
+                "query-string": "^6.2.0",
+                "qw": "~1.0.1",
+                "read": "~1.0.7",
+                "read-cmd-shim": "~1.0.1",
+                "read-installed": "~4.0.3",
+                "read-package-json": "^2.0.13",
+                "read-package-tree": "^5.2.2",
+                "readable-stream": "^3.1.1",
+                "readdir-scoped-modules": "*",
+                "request": "^2.88.0",
+                "retry": "^0.12.0",
+                "rimraf": "^2.6.3",
+                "safe-buffer": "^5.1.2",
+                "semver": "^5.6.0",
+                "sha": "~2.0.1",
+                "slide": "~1.1.6",
+                "sorted-object": "~2.0.1",
+                "sorted-union-stream": "~2.1.3",
+                "ssri": "^6.0.1",
+                "stringify-package": "^1.0.0",
+                "tar": "^4.4.8",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^1.3.0",
                 "uid-number": "0.0.6",
-                "umask": "1.1.0",
-                "unique-filename": "1.1.1",
-                "unpipe": "1.0.0",
-                "update-notifier": "2.5.0",
-                "uuid": "3.3.2",
-                "validate-npm-package-license": "3.0.4",
-                "validate-npm-package-name": "3.0.0",
-                "which": "1.3.1",
-                "worker-farm": "1.6.0",
-                "write-file-atomic": "2.4.2"
+                "umask": "~1.1.0",
+                "unique-filename": "^1.1.1",
+                "unpipe": "~1.0.0",
+                "update-notifier": "^2.5.0",
+                "uuid": "^3.3.2",
+                "validate-npm-package-license": "^3.0.4",
+                "validate-npm-package-name": "~3.0.0",
+                "which": "^1.3.1",
+                "worker-farm": "^1.6.0",
+                "write-file-atomic": "^2.4.2"
             },
             "dependencies": {
                 "JSONStream": {
                     "version": "1.3.5",
                     "bundled": true,
                     "requires": {
-                        "jsonparse": "1.3.1",
-                        "through": "2.3.8"
+                        "jsonparse": "^1.2.0",
+                        "through": ">=2.2.7 <3"
                     }
                 },
                 "abbrev": {
@@ -1440,31 +1444,31 @@
                     "version": "4.2.0",
                     "bundled": true,
                     "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                     }
                 },
                 "agentkeepalive": {
                     "version": "3.4.1",
                     "bundled": true,
                     "requires": {
-                        "humanize-ms": "1.2.1"
+                        "humanize-ms": "^1.2.1"
                     }
                 },
                 "ajv": {
                     "version": "5.5.2",
                     "bundled": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "ansi-align": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "string-width": "2.1.1"
+                        "string-width": "^2.0.0"
                     }
                 },
                 "ansi-regex": {
@@ -1475,7 +1479,7 @@
                     "version": "3.2.1",
                     "bundled": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "ansicolors": {
@@ -1498,28 +1502,28 @@
                     "version": "1.1.4",
                     "bundled": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -1532,7 +1536,7 @@
                     "version": "0.2.4",
                     "bundled": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "~2.1.0"
                     }
                 },
                 "assert-plus": {
@@ -1560,25 +1564,25 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "bin-links": {
                     "version": "1.1.2",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.3",
-                        "cmd-shim": "2.0.2",
-                        "gentle-fs": "2.0.1",
-                        "graceful-fs": "4.1.15",
-                        "write-file-atomic": "2.4.2"
+                        "bluebird": "^3.5.0",
+                        "cmd-shim": "^2.0.2",
+                        "gentle-fs": "^2.0.0",
+                        "graceful-fs": "^4.1.11",
+                        "write-file-atomic": "^2.3.0"
                     }
                 },
                 "block-stream": {
                     "version": "0.0.9",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "bluebird": {
@@ -1589,20 +1593,20 @@
                     "version": "1.3.0",
                     "bundled": true,
                     "requires": {
-                        "ansi-align": "2.0.0",
-                        "camelcase": "4.1.0",
-                        "chalk": "2.4.1",
-                        "cli-boxes": "1.0.0",
-                        "string-width": "2.1.1",
-                        "term-size": "1.2.0",
-                        "widest-line": "2.0.0"
+                        "ansi-align": "^2.0.0",
+                        "camelcase": "^4.0.0",
+                        "chalk": "^2.0.1",
+                        "cli-boxes": "^1.0.0",
+                        "string-width": "^2.0.0",
+                        "term-size": "^1.2.0",
+                        "widest-line": "^2.0.0"
                     }
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -1626,20 +1630,20 @@
                     "version": "11.3.2",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.3",
-                        "chownr": "1.1.1",
-                        "figgy-pudding": "3.5.1",
-                        "glob": "7.1.3",
-                        "graceful-fs": "4.1.15",
-                        "lru-cache": "5.1.1",
-                        "mississippi": "3.0.0",
-                        "mkdirp": "0.5.1",
-                        "move-concurrently": "1.0.1",
-                        "promise-inflight": "1.0.1",
-                        "rimraf": "2.6.3",
-                        "ssri": "6.0.1",
-                        "unique-filename": "1.1.1",
-                        "y18n": "4.0.0"
+                        "bluebird": "^3.5.3",
+                        "chownr": "^1.1.1",
+                        "figgy-pudding": "^3.5.1",
+                        "glob": "^7.1.3",
+                        "graceful-fs": "^4.1.15",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "ssri": "^6.0.1",
+                        "unique-filename": "^1.1.1",
+                        "y18n": "^4.0.0"
                     },
                     "dependencies": {
                         "chownr": {
@@ -1650,14 +1654,14 @@
                             "version": "5.1.1",
                             "bundled": true,
                             "requires": {
-                                "yallist": "3.0.3"
+                                "yallist": "^3.0.2"
                             }
                         },
                         "unique-filename": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "unique-slug": "2.0.0"
+                                "unique-slug": "^2.0.0"
                             }
                         },
                         "yallist": {
@@ -1686,9 +1690,9 @@
                     "version": "2.4.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "chownr": {
@@ -1703,7 +1707,7 @@
                     "version": "2.0.10",
                     "bundled": true,
                     "requires": {
-                        "ip-regex": "2.1.0"
+                        "ip-regex": "^2.1.0"
                     }
                 },
                 "cli-boxes": {
@@ -1714,26 +1718,26 @@
                     "version": "3.1.2",
                     "bundled": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^2.0.0",
+                        "strip-ansi": "^3.0.1"
                     }
                 },
                 "cli-table3": {
                     "version": "0.5.1",
                     "bundled": true,
                     "requires": {
-                        "colors": "1.3.3",
-                        "object-assign": "4.1.1",
-                        "string-width": "2.1.1"
+                        "colors": "^1.1.2",
+                        "object-assign": "^4.1.0",
+                        "string-width": "^2.1.1"
                     }
                 },
                 "cliui": {
                     "version": "4.1.0",
                     "bundled": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -1744,7 +1748,7 @@
                             "version": "4.0.0",
                             "bundled": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -1757,8 +1761,8 @@
                     "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.15",
-                        "mkdirp": "0.5.1"
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "~0.5.0"
                     }
                 },
                 "co": {
@@ -1773,7 +1777,7 @@
                     "version": "1.9.1",
                     "bundled": true,
                     "requires": {
-                        "color-name": "1.1.3"
+                        "color-name": "^1.1.1"
                     }
                 },
                 "color-name": {
@@ -1789,15 +1793,15 @@
                     "version": "1.5.4",
                     "bundled": true,
                     "requires": {
-                        "strip-ansi": "3.0.1",
-                        "wcwidth": "1.0.1"
+                        "strip-ansi": "^3.0.0",
+                        "wcwidth": "^1.0.0"
                     }
                 },
                 "combined-stream": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -1808,30 +1812,30 @@
                     "version": "1.6.2",
                     "bundled": true,
                     "requires": {
-                        "buffer-from": "1.0.0",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "typedarray": "0.0.6"
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -1840,20 +1844,20 @@
                     "version": "1.1.12",
                     "bundled": true,
                     "requires": {
-                        "ini": "1.3.5",
-                        "proto-list": "1.2.4"
+                        "ini": "^1.3.4",
+                        "proto-list": "~1.2.1"
                     }
                 },
                 "configstore": {
                     "version": "3.1.2",
                     "bundled": true,
                     "requires": {
-                        "dot-prop": "4.2.0",
-                        "graceful-fs": "4.1.15",
-                        "make-dir": "1.3.0",
-                        "unique-string": "1.0.0",
-                        "write-file-atomic": "2.4.2",
-                        "xdg-basedir": "3.0.0"
+                        "dot-prop": "^4.1.0",
+                        "graceful-fs": "^4.1.2",
+                        "make-dir": "^1.0.0",
+                        "unique-string": "^1.0.0",
+                        "write-file-atomic": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
                     }
                 },
                 "console-control-strings": {
@@ -1864,12 +1868,12 @@
                     "version": "1.0.5",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "iferr": "0.1.5",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.3",
-                        "run-queue": "1.0.3"
+                        "aproba": "^1.1.1",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "iferr": "^0.1.5",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.0"
                     },
                     "dependencies": {
                         "aproba": {
@@ -1890,16 +1894,16 @@
                     "version": "3.0.2",
                     "bundled": true,
                     "requires": {
-                        "capture-stack-trace": "1.0.0"
+                        "capture-stack-trace": "^1.0.0"
                     }
                 },
                 "cross-spawn": {
                     "version": "5.1.0",
                     "bundled": true,
                     "requires": {
-                        "lru-cache": "4.1.5",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "crypto-random-string": {
@@ -1914,7 +1918,7 @@
                     "version": "1.14.1",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     }
                 },
                 "debug": {
@@ -1950,7 +1954,7 @@
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "clone": "1.0.4"
+                        "clone": "^1.0.2"
                     }
                 },
                 "delayed-stream": {
@@ -1973,15 +1977,15 @@
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "asap": "2.0.6",
-                        "wrappy": "1.0.2"
+                        "asap": "^2.0.0",
+                        "wrappy": "1"
                     }
                 },
                 "dot-prop": {
                     "version": "4.2.0",
                     "bundled": true,
                     "requires": {
-                        "is-obj": "1.0.1"
+                        "is-obj": "^1.0.0"
                     }
                 },
                 "dotenv": {
@@ -1996,30 +2000,30 @@
                     "version": "3.6.0",
                     "bundled": true,
                     "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -2029,8 +2033,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1",
-                        "safer-buffer": "2.1.2"
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "editor": {
@@ -2041,14 +2045,14 @@
                     "version": "0.1.12",
                     "bundled": true,
                     "requires": {
-                        "iconv-lite": "0.4.23"
+                        "iconv-lite": "~0.4.13"
                     }
                 },
                 "end-of-stream": {
                     "version": "1.4.1",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 },
                 "err-code": {
@@ -2059,7 +2063,7 @@
                     "version": "0.1.7",
                     "bundled": true,
                     "requires": {
-                        "prr": "1.0.1"
+                        "prr": "~1.0.1"
                     }
                 },
                 "es6-promise": {
@@ -2070,7 +2074,7 @@
                     "version": "5.0.0",
                     "bundled": true,
                     "requires": {
-                        "es6-promise": "4.2.4"
+                        "es6-promise": "^4.0.3"
                     }
                 },
                 "escape-string-regexp": {
@@ -2081,13 +2085,13 @@
                     "version": "0.7.0",
                     "bundled": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     },
                     "dependencies": {
                         "get-stream": {
@@ -2124,35 +2128,35 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 },
                 "flush-write-stream": {
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -2165,37 +2169,37 @@
                     "version": "2.3.2",
                     "bundled": true,
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.19"
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "from2": {
                     "version": "2.3.0",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -2204,26 +2208,26 @@
                     "version": "1.2.5",
                     "bundled": true,
                     "requires": {
-                        "minipass": "2.3.3"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs-vacuum": {
                     "version": "1.2.10",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.15",
-                        "path-is-inside": "1.0.2",
-                        "rimraf": "2.6.3"
+                        "graceful-fs": "^4.1.2",
+                        "path-is-inside": "^1.0.1",
+                        "rimraf": "^2.5.2"
                     }
                 },
                 "fs-write-stream-atomic": {
                     "version": "1.0.10",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.15",
-                        "iferr": "0.1.5",
-                        "imurmurhash": "0.1.4",
-                        "readable-stream": "2.3.6"
+                        "graceful-fs": "^4.1.2",
+                        "iferr": "^0.1.5",
+                        "imurmurhash": "^0.1.4",
+                        "readable-stream": "1 || 2"
                     },
                     "dependencies": {
                         "iferr": {
@@ -2234,20 +2238,20 @@
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -2260,24 +2264,24 @@
                     "version": "1.0.11",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.15",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.3"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     },
                     "dependencies": {
                         "aproba": {
@@ -2288,9 +2292,9 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         }
                     }
@@ -2303,14 +2307,14 @@
                     "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "fs-vacuum": "1.2.10",
-                        "graceful-fs": "4.1.15",
-                        "iferr": "0.1.5",
-                        "mkdirp": "0.5.1",
-                        "path-is-inside": "1.0.2",
-                        "read-cmd-shim": "1.0.1",
-                        "slide": "1.1.6"
+                        "aproba": "^1.1.2",
+                        "fs-vacuum": "^1.2.10",
+                        "graceful-fs": "^4.1.11",
+                        "iferr": "^0.1.5",
+                        "mkdirp": "^0.5.1",
+                        "path-is-inside": "^1.0.2",
+                        "read-cmd-shim": "^1.0.1",
+                        "slide": "^1.1.6"
                     },
                     "dependencies": {
                         "aproba": {
@@ -2331,50 +2335,50 @@
                     "version": "4.1.0",
                     "bundled": true,
                     "requires": {
-                        "pump": "3.0.0"
+                        "pump": "^3.0.0"
                     }
                 },
                 "getpass": {
                     "version": "0.1.7",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     }
                 },
                 "glob": {
                     "version": "7.1.3",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "global-dirs": {
                     "version": "0.1.1",
                     "bundled": true,
                     "requires": {
-                        "ini": "1.3.5"
+                        "ini": "^1.3.4"
                     }
                 },
                 "got": {
                     "version": "6.7.1",
                     "bundled": true,
                     "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.1",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                     },
                     "dependencies": {
                         "get-stream": {
@@ -2395,8 +2399,8 @@
                     "version": "5.1.0",
                     "bundled": true,
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "has-flag": {
@@ -2419,7 +2423,7 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "agent-base": "4.2.0",
+                        "agent-base": "4",
                         "debug": "3.1.0"
                     }
                 },
@@ -2427,31 +2431,31 @@
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.2"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "https-proxy-agent": {
                     "version": "2.2.1",
                     "bundled": true,
                     "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
+                        "agent-base": "^4.1.0",
+                        "debug": "^3.1.0"
                     }
                 },
                 "humanize-ms": {
                     "version": "1.2.1",
                     "bundled": true,
                     "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                     }
                 },
                 "iconv-lite": {
                     "version": "0.4.23",
                     "bundled": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "iferr": {
@@ -2462,7 +2466,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "import-lazy": {
@@ -2477,8 +2481,8 @@
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2493,14 +2497,14 @@
                     "version": "1.10.3",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.3",
-                        "npm-package-arg": "6.1.0",
-                        "promzard": "0.3.0",
-                        "read": "1.0.7",
-                        "read-package-json": "2.0.13",
-                        "semver": "5.6.0",
-                        "validate-npm-package-license": "3.0.4",
-                        "validate-npm-package-name": "3.0.0"
+                        "glob": "^7.1.1",
+                        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+                        "promzard": "^0.3.0",
+                        "read": "~1.0.1",
+                        "read-package-json": "1 || 2",
+                        "semver": "2.x || 3.x || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1",
+                        "validate-npm-package-name": "^3.0.0"
                     }
                 },
                 "invert-kv": {
@@ -2519,7 +2523,7 @@
                     "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "ci-info": "1.6.0"
+                        "ci-info": "^1.0.0"
                     },
                     "dependencies": {
                         "ci-info": {
@@ -2532,22 +2536,22 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "cidr-regex": "2.0.10"
+                        "cidr-regex": "^2.0.10"
                     }
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-installed-globally": {
                     "version": "0.1.0",
                     "bundled": true,
                     "requires": {
-                        "global-dirs": "0.1.1",
-                        "is-path-inside": "1.0.1"
+                        "global-dirs": "^0.1.0",
+                        "is-path-inside": "^1.0.0"
                     }
                 },
                 "is-npm": {
@@ -2562,7 +2566,7 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "path-is-inside": "1.0.2"
+                        "path-is-inside": "^1.0.1"
                     }
                 },
                 "is-redirect": {
@@ -2632,7 +2636,7 @@
                     "version": "3.1.0",
                     "bundled": true,
                     "requires": {
-                        "package-json": "4.0.1"
+                        "package-json": "^4.0.0"
                     }
                 },
                 "lazy-property": {
@@ -2643,64 +2647,64 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                     }
                 },
                 "libcipm": {
                     "version": "3.0.3",
                     "bundled": true,
                     "requires": {
-                        "bin-links": "1.1.2",
-                        "bluebird": "3.5.3",
-                        "figgy-pudding": "3.5.1",
-                        "find-npm-prefix": "1.0.2",
-                        "graceful-fs": "4.1.15",
-                        "ini": "1.3.5",
-                        "lock-verify": "2.0.2",
-                        "mkdirp": "0.5.1",
-                        "npm-lifecycle": "2.1.0",
-                        "npm-logical-tree": "1.2.1",
-                        "npm-package-arg": "6.1.0",
-                        "pacote": "9.4.1",
-                        "read-package-json": "2.0.13",
-                        "rimraf": "2.6.3",
-                        "worker-farm": "1.6.0"
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^3.5.1",
+                        "find-npm-prefix": "^1.0.2",
+                        "graceful-fs": "^4.1.11",
+                        "ini": "^1.3.5",
+                        "lock-verify": "^2.0.2",
+                        "mkdirp": "^0.5.1",
+                        "npm-lifecycle": "^2.0.3",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "pacote": "^9.1.0",
+                        "read-package-json": "^2.0.13",
+                        "rimraf": "^2.6.2",
+                        "worker-farm": "^1.6.0"
                     }
                 },
                 "libnpm": {
                     "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "bin-links": "1.1.2",
-                        "bluebird": "3.5.3",
-                        "find-npm-prefix": "1.0.2",
-                        "libnpmaccess": "3.0.1",
-                        "libnpmconfig": "1.2.1",
-                        "libnpmhook": "5.0.2",
-                        "libnpmorg": "1.0.0",
-                        "libnpmpublish": "1.1.1",
-                        "libnpmsearch": "2.0.0",
-                        "libnpmteam": "1.0.1",
-                        "lock-verify": "2.0.2",
-                        "npm-lifecycle": "2.1.0",
-                        "npm-logical-tree": "1.2.1",
-                        "npm-package-arg": "6.1.0",
-                        "npm-profile": "4.0.1",
-                        "npm-registry-fetch": "3.9.0",
-                        "npmlog": "4.1.2",
-                        "pacote": "9.4.1",
-                        "read-package-json": "2.0.13",
-                        "stringify-package": "1.0.0"
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.3",
+                        "find-npm-prefix": "^1.0.2",
+                        "libnpmaccess": "^3.0.1",
+                        "libnpmconfig": "^1.2.1",
+                        "libnpmhook": "^5.0.2",
+                        "libnpmorg": "^1.0.0",
+                        "libnpmpublish": "^1.1.0",
+                        "libnpmsearch": "^2.0.0",
+                        "libnpmteam": "^1.0.1",
+                        "lock-verify": "^2.0.2",
+                        "npm-lifecycle": "^2.1.0",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-profile": "^4.0.1",
+                        "npm-registry-fetch": "^3.8.0",
+                        "npmlog": "^4.1.2",
+                        "pacote": "^9.2.3",
+                        "read-package-json": "^2.0.13",
+                        "stringify-package": "^1.0.0"
                     }
                 },
                 "libnpmaccess": {
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "2.0.0",
-                        "get-stream": "4.1.0",
-                        "npm-package-arg": "6.1.0",
-                        "npm-registry-fetch": "3.9.0"
+                        "aproba": "^2.0.0",
+                        "get-stream": "^4.0.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-registry-fetch": "^3.8.0"
                     },
                     "dependencies": {
                         "aproba": {
@@ -2713,38 +2717,38 @@
                     "version": "1.2.1",
                     "bundled": true,
                     "requires": {
-                        "figgy-pudding": "3.5.1",
-                        "find-up": "3.0.0",
-                        "ini": "1.3.5"
+                        "figgy-pudding": "^3.5.1",
+                        "find-up": "^3.0.0",
+                        "ini": "^1.3.5"
                     },
                     "dependencies": {
                         "find-up": {
                             "version": "3.0.0",
                             "bundled": true,
                             "requires": {
-                                "locate-path": "3.0.0"
+                                "locate-path": "^3.0.0"
                             }
                         },
                         "locate-path": {
                             "version": "3.0.0",
                             "bundled": true,
                             "requires": {
-                                "p-locate": "3.0.0",
-                                "path-exists": "3.0.0"
+                                "p-locate": "^3.0.0",
+                                "path-exists": "^3.0.0"
                             }
                         },
                         "p-limit": {
                             "version": "2.1.0",
                             "bundled": true,
                             "requires": {
-                                "p-try": "2.0.0"
+                                "p-try": "^2.0.0"
                             }
                         },
                         "p-locate": {
                             "version": "3.0.0",
                             "bundled": true,
                             "requires": {
-                                "p-limit": "2.1.0"
+                                "p-limit": "^2.0.0"
                             }
                         },
                         "p-try": {
@@ -2757,20 +2761,20 @@
                     "version": "5.0.2",
                     "bundled": true,
                     "requires": {
-                        "aproba": "2.0.0",
-                        "figgy-pudding": "3.5.1",
-                        "get-stream": "4.1.0",
-                        "npm-registry-fetch": "3.9.0"
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^3.8.0"
                     }
                 },
                 "libnpmorg": {
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "aproba": "2.0.0",
-                        "figgy-pudding": "3.5.1",
-                        "get-stream": "4.1.0",
-                        "npm-registry-fetch": "3.9.0"
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^3.8.0"
                     },
                     "dependencies": {
                         "aproba": {
@@ -2783,34 +2787,34 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "2.0.0",
-                        "figgy-pudding": "3.5.1",
-                        "get-stream": "4.1.0",
-                        "lodash.clonedeep": "4.5.0",
-                        "normalize-package-data": "2.5.0",
-                        "npm-package-arg": "6.1.0",
-                        "npm-registry-fetch": "3.9.0",
-                        "semver": "5.6.0",
-                        "ssri": "6.0.1"
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.0.0",
+                        "lodash.clonedeep": "^4.5.0",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-registry-fetch": "^3.8.0",
+                        "semver": "^5.5.1",
+                        "ssri": "^6.0.1"
                     }
                 },
                 "libnpmsearch": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "figgy-pudding": "3.5.1",
-                        "get-stream": "4.1.0",
-                        "npm-registry-fetch": "3.9.0"
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^3.8.0"
                     }
                 },
                 "libnpmteam": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "2.0.0",
-                        "figgy-pudding": "3.5.1",
-                        "get-stream": "4.1.0",
-                        "npm-registry-fetch": "3.9.0"
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^3.8.0"
                     },
                     "dependencies": {
                         "aproba": {
@@ -2823,37 +2827,37 @@
                     "version": "10.2.0",
                     "bundled": true,
                     "requires": {
-                        "dotenv": "5.0.1",
-                        "npm-package-arg": "6.1.0",
-                        "rimraf": "2.6.3",
-                        "safe-buffer": "5.1.2",
-                        "update-notifier": "2.5.0",
-                        "which": "1.3.1",
-                        "y18n": "4.0.0",
-                        "yargs": "11.0.0"
+                        "dotenv": "^5.0.1",
+                        "npm-package-arg": "^6.0.0",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.0",
+                        "update-notifier": "^2.3.0",
+                        "which": "^1.3.0",
+                        "y18n": "^4.0.0",
+                        "yargs": "^11.0.0"
                     }
                 },
                 "locate-path": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "lock-verify": {
                     "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "npm-package-arg": "6.1.0",
-                        "semver": "5.6.0"
+                        "npm-package-arg": "^5.1.2 || 6",
+                        "semver": "^5.4.1"
                     }
                 },
                 "lockfile": {
                     "version": "1.0.4",
                     "bundled": true,
                     "requires": {
-                        "signal-exit": "3.0.2"
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "lodash._baseindexof": {
@@ -2864,8 +2868,8 @@
                     "version": "4.6.0",
                     "bundled": true,
                     "requires": {
-                        "lodash._createset": "4.0.3",
-                        "lodash._root": "3.0.1"
+                        "lodash._createset": "~4.0.0",
+                        "lodash._root": "~3.0.0"
                     }
                 },
                 "lodash._bindcallback": {
@@ -2880,7 +2884,7 @@
                     "version": "3.1.2",
                     "bundled": true,
                     "requires": {
-                        "lodash._getnative": "3.9.1"
+                        "lodash._getnative": "^3.0.0"
                     }
                 },
                 "lodash._createset": {
@@ -2923,32 +2927,32 @@
                     "version": "4.1.5",
                     "bundled": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "make-dir": {
                     "version": "1.3.0",
                     "bundled": true,
                     "requires": {
-                        "pify": "3.0.0"
+                        "pify": "^3.0.0"
                     }
                 },
                 "make-fetch-happen": {
                     "version": "4.0.1",
                     "bundled": true,
                     "requires": {
-                        "agentkeepalive": "3.4.1",
-                        "cacache": "11.3.2",
-                        "http-cache-semantics": "3.8.1",
-                        "http-proxy-agent": "2.1.0",
-                        "https-proxy-agent": "2.2.1",
-                        "lru-cache": "4.1.5",
-                        "mississippi": "3.0.0",
-                        "node-fetch-npm": "2.0.2",
-                        "promise-retry": "1.1.1",
-                        "socks-proxy-agent": "4.0.1",
-                        "ssri": "6.0.1"
+                        "agentkeepalive": "^3.4.1",
+                        "cacache": "^11.0.1",
+                        "http-cache-semantics": "^3.8.1",
+                        "http-proxy-agent": "^2.1.0",
+                        "https-proxy-agent": "^2.2.1",
+                        "lru-cache": "^4.1.2",
+                        "mississippi": "^3.0.0",
+                        "node-fetch-npm": "^2.0.2",
+                        "promise-retry": "^1.1.1",
+                        "socks-proxy-agent": "^4.0.0",
+                        "ssri": "^6.0.0"
                     }
                 },
                 "meant": {
@@ -2959,7 +2963,7 @@
                     "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                     }
                 },
                 "mime-db": {
@@ -2970,7 +2974,7 @@
                     "version": "2.1.19",
                     "bundled": true,
                     "requires": {
-                        "mime-db": "1.35.0"
+                        "mime-db": "~1.35.0"
                     }
                 },
                 "mimic-fn": {
@@ -2981,7 +2985,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -2992,8 +2996,8 @@
                     "version": "2.3.3",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.1.2",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
                     },
                     "dependencies": {
                         "yallist": {
@@ -3006,23 +3010,23 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "minipass": "2.3.3"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mississippi": {
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.6.0",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "3.0.0",
-                        "pumpify": "1.5.1",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^3.0.0",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                     }
                 },
                 "mkdirp": {
@@ -3036,12 +3040,12 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "copy-concurrently": "1.0.5",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.3",
-                        "run-queue": "1.0.3"
+                        "aproba": "^1.1.1",
+                        "copy-concurrently": "^1.0.0",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.3"
                     },
                     "dependencies": {
                         "aproba": {
@@ -3062,34 +3066,34 @@
                     "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "encoding": "0.1.12",
-                        "json-parse-better-errors": "1.0.2",
-                        "safe-buffer": "5.1.2"
+                        "encoding": "^0.1.11",
+                        "json-parse-better-errors": "^1.0.0",
+                        "safe-buffer": "^5.1.1"
                     }
                 },
                 "node-gyp": {
                     "version": "3.8.0",
                     "bundled": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "glob": "7.1.3",
-                        "graceful-fs": "4.1.15",
-                        "mkdirp": "0.5.1",
-                        "nopt": "3.0.6",
-                        "npmlog": "4.1.2",
-                        "osenv": "0.1.5",
-                        "request": "2.88.0",
-                        "rimraf": "2.6.3",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "which": "1.3.1"
+                        "fstream": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "^0.5.0",
+                        "nopt": "2 || 3",
+                        "npmlog": "0 || 1 || 2 || 3 || 4",
+                        "osenv": "0",
+                        "request": "^2.87.0",
+                        "rimraf": "2",
+                        "semver": "~5.3.0",
+                        "tar": "^2.0.0",
+                        "which": "1"
                     },
                     "dependencies": {
                         "nopt": {
                             "version": "3.0.6",
                             "bundled": true,
                             "requires": {
-                                "abbrev": "1.1.1"
+                                "abbrev": "1"
                             }
                         },
                         "semver": {
@@ -3100,9 +3104,9 @@
                             "version": "2.2.1",
                             "bundled": true,
                             "requires": {
-                                "block-stream": "0.0.9",
-                                "fstream": "1.0.11",
-                                "inherits": "2.0.3"
+                                "block-stream": "*",
+                                "fstream": "^1.0.2",
+                                "inherits": "2"
                             }
                         }
                     }
@@ -3111,25 +3115,25 @@
                     "version": "4.0.1",
                     "bundled": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "normalize-package-data": {
                     "version": "2.5.0",
                     "bundled": true,
                     "requires": {
-                        "hosted-git-info": "2.7.1",
-                        "resolve": "1.10.0",
-                        "semver": "5.6.0",
-                        "validate-npm-package-license": "3.0.4"
+                        "hosted-git-info": "^2.1.4",
+                        "resolve": "^1.10.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                     },
                     "dependencies": {
                         "resolve": {
                             "version": "1.10.0",
                             "bundled": true,
                             "requires": {
-                                "path-parse": "1.0.6"
+                                "path-parse": "^1.0.6"
                             }
                         }
                     }
@@ -3138,8 +3142,8 @@
                     "version": "1.3.2",
                     "bundled": true,
                     "requires": {
-                        "cli-table3": "0.5.1",
-                        "console-control-strings": "1.1.0"
+                        "cli-table3": "^0.5.0",
+                        "console-control-strings": "^1.1.0"
                     }
                 },
                 "npm-bundled": {
@@ -3154,21 +3158,21 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "semver": "5.6.0"
+                        "semver": "^2.3.0 || 3.x || 4 || 5"
                     }
                 },
                 "npm-lifecycle": {
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "byline": "5.0.0",
-                        "graceful-fs": "4.1.15",
-                        "node-gyp": "3.8.0",
-                        "resolve-from": "4.0.0",
-                        "slide": "1.1.6",
+                        "byline": "^5.0.0",
+                        "graceful-fs": "^4.1.11",
+                        "node-gyp": "^3.8.0",
+                        "resolve-from": "^4.0.0",
+                        "slide": "^1.1.6",
                         "uid-number": "0.0.6",
-                        "umask": "1.1.0",
-                        "which": "1.3.1"
+                        "umask": "^1.1.0",
+                        "which": "^1.3.1"
                     }
                 },
                 "npm-logical-tree": {
@@ -3179,55 +3183,55 @@
                     "version": "6.1.0",
                     "bundled": true,
                     "requires": {
-                        "hosted-git-info": "2.7.1",
-                        "osenv": "0.1.5",
-                        "semver": "5.6.0",
-                        "validate-npm-package-name": "3.0.0"
+                        "hosted-git-info": "^2.6.0",
+                        "osenv": "^0.1.5",
+                        "semver": "^5.5.0",
+                        "validate-npm-package-name": "^3.0.0"
                     }
                 },
                 "npm-packlist": {
                     "version": "1.3.0",
                     "bundled": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.6"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npm-pick-manifest": {
                     "version": "2.2.3",
                     "bundled": true,
                     "requires": {
-                        "figgy-pudding": "3.5.1",
-                        "npm-package-arg": "6.1.0",
-                        "semver": "5.6.0"
+                        "figgy-pudding": "^3.5.1",
+                        "npm-package-arg": "^6.0.0",
+                        "semver": "^5.4.1"
                     }
                 },
                 "npm-profile": {
                     "version": "4.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "2.0.0",
-                        "figgy-pudding": "3.5.1",
-                        "npm-registry-fetch": "3.9.0"
+                        "aproba": "^1.1.2 || 2",
+                        "figgy-pudding": "^3.4.1",
+                        "npm-registry-fetch": "^3.8.0"
                     }
                 },
                 "npm-registry-fetch": {
                     "version": "3.9.0",
                     "bundled": true,
                     "requires": {
-                        "JSONStream": "1.3.5",
-                        "bluebird": "3.5.3",
-                        "figgy-pudding": "3.5.1",
-                        "lru-cache": "4.1.5",
-                        "make-fetch-happen": "4.0.1",
-                        "npm-package-arg": "6.1.0"
+                        "JSONStream": "^1.3.4",
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^3.4.1",
+                        "lru-cache": "^4.1.3",
+                        "make-fetch-happen": "^4.0.1",
+                        "npm-package-arg": "^6.1.0"
                     }
                 },
                 "npm-run-path": {
                     "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "path-key": "2.0.1"
+                        "path-key": "^2.0.0"
                     }
                 },
                 "npm-user-validate": {
@@ -3238,10 +3242,10 @@
                     "version": "4.1.2",
                     "bundled": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -3260,7 +3264,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "opener": {
@@ -3275,9 +3279,9 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "os-tmpdir": {
@@ -3288,8 +3292,8 @@
                     "version": "0.1.5",
                     "bundled": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "p-finally": {
@@ -3300,14 +3304,14 @@
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "p-try": "1.0.0"
+                        "p-try": "^1.0.0"
                     }
                 },
                 "p-locate": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "p-limit": "1.2.0"
+                        "p-limit": "^1.1.0"
                     }
                 },
                 "p-try": {
@@ -3318,58 +3322,58 @@
                     "version": "4.0.1",
                     "bundled": true,
                     "requires": {
-                        "got": "6.7.1",
-                        "registry-auth-token": "3.3.2",
-                        "registry-url": "3.1.0",
-                        "semver": "5.6.0"
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
                     }
                 },
                 "pacote": {
                     "version": "9.4.1",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.3",
-                        "cacache": "11.3.2",
-                        "figgy-pudding": "3.5.1",
-                        "get-stream": "4.1.0",
-                        "glob": "7.1.3",
-                        "lru-cache": "5.1.1",
-                        "make-fetch-happen": "4.0.1",
-                        "minimatch": "3.0.4",
-                        "minipass": "2.3.5",
-                        "mississippi": "3.0.0",
-                        "mkdirp": "0.5.1",
-                        "normalize-package-data": "2.5.0",
-                        "npm-package-arg": "6.1.0",
-                        "npm-packlist": "1.3.0",
-                        "npm-pick-manifest": "2.2.3",
-                        "npm-registry-fetch": "3.9.0",
-                        "osenv": "0.1.5",
-                        "promise-inflight": "1.0.1",
-                        "promise-retry": "1.1.1",
-                        "protoduck": "5.0.1",
-                        "rimraf": "2.6.3",
-                        "safe-buffer": "5.1.2",
-                        "semver": "5.6.0",
-                        "ssri": "6.0.1",
-                        "tar": "4.4.8",
-                        "unique-filename": "1.1.1",
-                        "which": "1.3.1"
+                        "bluebird": "^3.5.3",
+                        "cacache": "^11.3.2",
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.1.0",
+                        "glob": "^7.1.3",
+                        "lru-cache": "^5.1.1",
+                        "make-fetch-happen": "^4.0.1",
+                        "minimatch": "^3.0.4",
+                        "minipass": "^2.3.5",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-packlist": "^1.1.12",
+                        "npm-pick-manifest": "^2.2.3",
+                        "npm-registry-fetch": "^3.8.0",
+                        "osenv": "^0.1.5",
+                        "promise-inflight": "^1.0.1",
+                        "promise-retry": "^1.1.1",
+                        "protoduck": "^5.0.1",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.2",
+                        "semver": "^5.6.0",
+                        "ssri": "^6.0.1",
+                        "tar": "^4.4.8",
+                        "unique-filename": "^1.1.1",
+                        "which": "^1.3.1"
                     },
                     "dependencies": {
                         "lru-cache": {
                             "version": "5.1.1",
                             "bundled": true,
                             "requires": {
-                                "yallist": "3.0.3"
+                                "yallist": "^3.0.2"
                             }
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2",
-                                "yallist": "3.0.3"
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
                             }
                         },
                         "yallist": {
@@ -3382,29 +3386,29 @@
                     "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -3453,8 +3457,8 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "err-code": "1.1.2",
-                        "retry": "0.10.1"
+                        "err-code": "^1.0.0",
+                        "retry": "^0.10.0"
                     },
                     "dependencies": {
                         "retry": {
@@ -3467,7 +3471,7 @@
                     "version": "0.3.0",
                     "bundled": true,
                     "requires": {
-                        "read": "1.0.7"
+                        "read": "1"
                     }
                 },
                 "proto-list": {
@@ -3478,7 +3482,7 @@
                     "version": "5.0.1",
                     "bundled": true,
                     "requires": {
-                        "genfun": "5.0.0"
+                        "genfun": "^5.0.0"
                     }
                 },
                 "prr": {
@@ -3497,25 +3501,25 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                     }
                 },
                 "pumpify": {
                     "version": "1.5.1",
                     "bundled": true,
                     "requires": {
-                        "duplexify": "3.6.0",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.6.0",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                     },
                     "dependencies": {
                         "pump": {
                             "version": "2.0.1",
                             "bundled": true,
                             "requires": {
-                                "end-of-stream": "1.4.1",
-                                "once": "1.4.0"
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
                             }
                         }
                     }
@@ -3536,8 +3540,8 @@
                     "version": "6.2.0",
                     "bundled": true,
                     "requires": {
-                        "decode-uri-component": "0.2.0",
-                        "strict-uri-encode": "2.0.0"
+                        "decode-uri-component": "^0.2.0",
+                        "strict-uri-encode": "^2.0.0"
                     }
                 },
                 "qw": {
@@ -3548,10 +3552,10 @@
                     "version": "1.2.7",
                     "bundled": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -3564,109 +3568,109 @@
                     "version": "1.0.7",
                     "bundled": true,
                     "requires": {
-                        "mute-stream": "0.0.7"
+                        "mute-stream": "~0.0.4"
                     }
                 },
                 "read-cmd-shim": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.15"
+                        "graceful-fs": "^4.1.2"
                     }
                 },
                 "read-installed": {
                     "version": "4.0.3",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "graceful-fs": "4.1.15",
-                        "read-package-json": "2.0.13",
-                        "readdir-scoped-modules": "1.0.2",
-                        "semver": "5.6.0",
-                        "slide": "1.1.6",
-                        "util-extend": "1.0.3"
+                        "debuglog": "^1.0.1",
+                        "graceful-fs": "^4.1.2",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "slide": "~1.1.3",
+                        "util-extend": "^1.0.1"
                     }
                 },
                 "read-package-json": {
                     "version": "2.0.13",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.3",
-                        "graceful-fs": "4.1.15",
-                        "json-parse-better-errors": "1.0.2",
-                        "normalize-package-data": "2.5.0",
-                        "slash": "1.0.0"
+                        "glob": "^7.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "json-parse-better-errors": "^1.0.1",
+                        "normalize-package-data": "^2.0.0",
+                        "slash": "^1.0.0"
                     }
                 },
                 "read-package-tree": {
                     "version": "5.2.2",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "once": "1.4.0",
-                        "read-package-json": "2.0.13",
-                        "readdir-scoped-modules": "1.0.2"
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "once": "^1.3.0",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0"
                     }
                 },
                 "readable-stream": {
                     "version": "3.1.1",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "string_decoder": "1.2.0",
-                        "util-deprecate": "1.0.2"
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 },
                 "readdir-scoped-modules": {
                     "version": "1.0.2",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "graceful-fs": "4.1.15",
-                        "once": "1.4.0"
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "graceful-fs": "^4.1.2",
+                        "once": "^1.3.0"
                     }
                 },
                 "registry-auth-token": {
                     "version": "3.3.2",
                     "bundled": true,
                     "requires": {
-                        "rc": "1.2.7",
-                        "safe-buffer": "5.1.2"
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "registry-url": {
                     "version": "3.1.0",
                     "bundled": true,
                     "requires": {
-                        "rc": "1.2.7"
+                        "rc": "^1.0.1"
                     }
                 },
                 "request": {
                     "version": "2.88.0",
                     "bundled": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.2",
-                        "har-validator": "5.1.0",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.19",
-                        "oauth-sign": "0.9.0",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     }
                 },
                 "require-directory": {
@@ -3689,14 +3693,14 @@
                     "version": "2.6.3",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.3"
+                        "glob": "^7.1.3"
                     }
                 },
                 "run-queue": {
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0"
+                        "aproba": "^1.1.1"
                     },
                     "dependencies": {
                         "aproba": {
@@ -3721,7 +3725,7 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "semver": "5.6.0"
+                        "semver": "^5.0.3"
                     }
                 },
                 "set-blocking": {
@@ -3732,28 +3736,28 @@
                     "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.15",
-                        "readable-stream": "2.3.6"
+                        "graceful-fs": "^4.1.2",
+                        "readable-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -3762,7 +3766,7 @@
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "shebang-regex": "1.0.0"
+                        "shebang-regex": "^1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -3789,16 +3793,16 @@
                     "version": "2.2.0",
                     "bundled": true,
                     "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "4.0.1"
+                        "ip": "^1.1.5",
+                        "smart-buffer": "^4.0.1"
                     }
                 },
                 "socks-proxy-agent": {
                     "version": "4.0.1",
                     "bundled": true,
                     "requires": {
-                        "agent-base": "4.2.0",
-                        "socks": "2.2.0"
+                        "agent-base": "~4.2.0",
+                        "socks": "~2.2.0"
                     }
                 },
                 "sorted-object": {
@@ -3809,16 +3813,16 @@
                     "version": "2.1.3",
                     "bundled": true,
                     "requires": {
-                        "from2": "1.3.0",
-                        "stream-iterate": "1.2.0"
+                        "from2": "^1.3.0",
+                        "stream-iterate": "^1.1.0"
                     },
                     "dependencies": {
                         "from2": {
                             "version": "1.3.0",
                             "bundled": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "1.1.14"
+                                "inherits": "~2.0.1",
+                                "readable-stream": "~1.1.10"
                             }
                         },
                         "isarray": {
@@ -3829,10 +3833,10 @@
                             "version": "1.1.14",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "string_decoder": {
@@ -3845,8 +3849,8 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "spdx-expression-parse": "3.0.0",
-                        "spdx-license-ids": "3.0.3"
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
                     }
                 },
                 "spdx-exceptions": {
@@ -3857,8 +3861,8 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "spdx-exceptions": "2.1.0",
-                        "spdx-license-ids": "3.0.3"
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
                     }
                 },
                 "spdx-license-ids": {
@@ -3869,58 +3873,58 @@
                     "version": "1.14.2",
                     "bundled": true,
                     "requires": {
-                        "asn1": "0.2.4",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.2",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.2",
-                        "getpass": "0.1.7",
-                        "jsbn": "0.1.1",
-                        "safer-buffer": "2.1.2",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.0.2",
+                        "tweetnacl": "~0.14.0"
                     }
                 },
                 "ssri": {
                     "version": "6.0.1",
                     "bundled": true,
                     "requires": {
-                        "figgy-pudding": "3.5.1"
+                        "figgy-pudding": "^3.5.1"
                     }
                 },
                 "stream-each": {
                     "version": "1.2.2",
                     "bundled": true,
                     "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                     }
                 },
                 "stream-iterate": {
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "readable-stream": "^2.1.5",
+                        "stream-shift": "^1.0.0"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -3937,8 +3941,8 @@
                     "version": "2.1.1",
                     "bundled": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -3953,7 +3957,7 @@
                             "version": "4.0.0",
                             "bundled": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -3962,7 +3966,7 @@
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "stringify-package": {
@@ -3973,7 +3977,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-eof": {
@@ -3988,20 +3992,20 @@
                     "version": "5.4.0",
                     "bundled": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 },
                 "tar": {
                     "version": "4.4.8",
                     "bundled": true,
                     "requires": {
-                        "chownr": "1.1.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.3.5",
-                        "minizlib": "1.1.1",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.2",
-                        "yallist": "3.0.3"
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.2"
                     },
                     "dependencies": {
                         "chownr": {
@@ -4012,8 +4016,8 @@
                             "version": "2.3.5",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2",
-                                "yallist": "3.0.3"
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
                             }
                         },
                         "yallist": {
@@ -4026,7 +4030,7 @@
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "execa": "0.7.0"
+                        "execa": "^0.7.0"
                     }
                 },
                 "text-table": {
@@ -4041,28 +4045,28 @@
                     "version": "2.0.3",
                     "bundled": true,
                     "requires": {
-                        "readable-stream": "2.3.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
                     },
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.2",
-                                "string_decoder": "1.1.1",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
                             "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "safe-buffer": "5.1.2"
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
@@ -4079,15 +4083,15 @@
                     "version": "2.4.3",
                     "bundled": true,
                     "requires": {
-                        "psl": "1.1.29",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
                     "version": "0.6.0",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -4111,21 +4115,21 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "unique-slug": "2.0.0"
+                        "unique-slug": "^2.0.0"
                     }
                 },
                 "unique-slug": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "imurmurhash": "0.1.4"
+                        "imurmurhash": "^0.1.4"
                     }
                 },
                 "unique-string": {
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "crypto-random-string": "1.0.0"
+                        "crypto-random-string": "^1.0.0"
                     }
                 },
                 "unpipe": {
@@ -4140,23 +4144,23 @@
                     "version": "2.5.0",
                     "bundled": true,
                     "requires": {
-                        "boxen": "1.3.0",
-                        "chalk": "2.4.1",
-                        "configstore": "3.1.2",
-                        "import-lazy": "2.1.0",
-                        "is-ci": "1.1.0",
-                        "is-installed-globally": "0.1.0",
-                        "is-npm": "1.0.0",
-                        "latest-version": "3.1.0",
-                        "semver-diff": "2.1.0",
-                        "xdg-basedir": "3.0.0"
+                        "boxen": "^1.2.1",
+                        "chalk": "^2.0.1",
+                        "configstore": "^3.0.0",
+                        "import-lazy": "^2.1.0",
+                        "is-ci": "^1.0.10",
+                        "is-installed-globally": "^0.1.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
                     }
                 },
                 "url-parse-lax": {
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "prepend-http": "1.0.4"
+                        "prepend-http": "^1.0.1"
                     }
                 },
                 "util-deprecate": {
@@ -4175,38 +4179,38 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "spdx-correct": "3.0.0",
-                        "spdx-expression-parse": "3.0.0"
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
                     }
                 },
                 "validate-npm-package-name": {
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "builtins": "1.0.3"
+                        "builtins": "^1.0.3"
                     }
                 },
                 "verror": {
                     "version": "1.10.0",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
+                        "assert-plus": "^1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
+                        "extsprintf": "^1.2.0"
                     }
                 },
                 "wcwidth": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "defaults": "1.0.3"
+                        "defaults": "^1.0.3"
                     }
                 },
                 "which": {
                     "version": "1.3.1",
                     "bundled": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 },
                 "which-module": {
@@ -4217,16 +4221,16 @@
                     "version": "1.1.2",
                     "bundled": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     },
                     "dependencies": {
                         "string-width": {
                             "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         }
                     }
@@ -4235,31 +4239,31 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "string-width": "2.1.1"
+                        "string-width": "^2.1.1"
                     }
                 },
                 "worker-farm": {
                     "version": "1.6.0",
                     "bundled": true,
                     "requires": {
-                        "errno": "0.1.7"
+                        "errno": "~0.1.7"
                     }
                 },
                 "wrap-ansi": {
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
                     },
                     "dependencies": {
                         "string-width": {
                             "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         }
                     }
@@ -4272,9 +4276,9 @@
                     "version": "2.4.2",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.15",
-                        "imurmurhash": "0.1.4",
-                        "signal-exit": "3.0.2"
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "xdg-basedir": {
@@ -4297,18 +4301,18 @@
                     "version": "11.0.0",
                     "bundled": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
                     },
                     "dependencies": {
                         "y18n": {
@@ -4321,7 +4325,7 @@
                     "version": "9.0.2",
                     "bundled": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -4337,19 +4341,13 @@
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -4358,7 +4356,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "optionator": {
@@ -4367,12 +4365,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "os-tmpdir": {
@@ -4380,6 +4378,15 @@
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
+        },
+        "parent-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+            "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -4391,6 +4398,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
             "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
             "dev": true
         },
         "path-to-regexp": {
@@ -4421,42 +4434,15 @@
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
-        "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "2.0.4"
-            }
-        },
-        "pluralize": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-            "dev": true
-        },
         "postcss": {
             "version": "6.0.22",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
             "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "source-map": "0.6.1",
-                "supports-color": "5.4.0"
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
             },
             "dependencies": {
                 "supports-color": {
@@ -4465,7 +4451,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -4483,15 +4469,9 @@
             "dev": true
         },
         "progress": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-            "dev": true
-        },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
         "psl": {
@@ -4515,19 +4495,19 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "regexpp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-            "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
             "dev": true
         },
         "request": {
@@ -4535,26 +4515,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.7",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.1.0",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.20",
-                "oauth-sign": "0.9.0",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.4.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             },
             "dependencies": {
                 "qs": {
@@ -4564,23 +4544,13 @@
                 }
             }
         },
-        "require-uncached": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-            "dev": true,
-            "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
-            }
-        },
         "requizzle": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
             "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
             "dev": true,
             "requires": {
-                "underscore": "1.6.0"
+                "underscore": "~1.6.0"
             },
             "dependencies": {
                 "underscore": {
@@ -4592,9 +4562,9 @@
             }
         },
         "resolve-from": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
         },
         "restore-cursor": {
@@ -4603,17 +4573,33 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.1.3"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
             }
         },
         "run-async": {
@@ -4622,22 +4608,16 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
-        "rx-lite": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-            "dev": true
-        },
-        "rx-lite-aggregates": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+        "rxjs": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+            "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
             "dev": true,
             "requires": {
-                "rx-lite": "4.0.8"
+                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -4662,22 +4642,22 @@
             "integrity": "sha512-52ThA+Z7h6BnvpSVbURwChl10XZrps5q7ytjTwWcIe9bmJwnVP6cpEVK2NvDOUhGupoqAvNbUz3cpnJDp4+/pg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "htmlparser2": "3.9.2",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.escaperegexp": "4.1.2",
-                "lodash.isplainobject": "4.0.6",
-                "lodash.isstring": "4.0.1",
-                "lodash.mergewith": "4.6.1",
-                "postcss": "6.0.22",
-                "srcset": "1.0.0",
-                "xtend": "4.0.1"
+                "chalk": "^2.3.0",
+                "htmlparser2": "^3.9.0",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.mergewith": "^4.6.0",
+                "postcss": "^6.0.14",
+                "srcset": "^1.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "semver": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
             "dev": true
         },
         "shebang-command": {
@@ -4686,7 +4666,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -4707,13 +4687,13 @@
             "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
             "dev": true,
             "requires": {
-                "@sinonjs/formatio": "2.0.0",
-                "diff": "3.5.0",
-                "lodash.get": "4.4.2",
-                "lolex": "2.3.2",
-                "nise": "1.3.3",
-                "supports-color": "5.4.0",
-                "type-detect": "4.0.8"
+                "@sinonjs/formatio": "^2.0.0",
+                "diff": "^3.1.0",
+                "lodash.get": "^4.4.2",
+                "lolex": "^2.2.0",
+                "nise": "^1.2.0",
+                "supports-color": "^5.1.0",
+                "type-detect": "^4.0.5"
             },
             "dependencies": {
                 "supports-color": {
@@ -4722,18 +4702,20 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
         },
         "slice-ansi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-            "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "source-map": {
@@ -4754,8 +4736,8 @@
             "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3",
-                "number-is-nan": "1.0.1"
+                "array-uniq": "^1.0.2",
+                "number-is-nan": "^1.0.0"
             }
         },
         "sshpk": {
@@ -4763,15 +4745,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "string-width": {
@@ -4780,8 +4762,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string_decoder": {
@@ -4790,7 +4772,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -4799,15 +4781,7 @@
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                }
+                "ansi-regex": "^3.0.0"
             }
         },
         "strip-json-comments": {
@@ -4817,35 +4791,82 @@
             "dev": true
         },
         "supports-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-            "dev": true
-        },
-        "table": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-            "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.4.1",
-                "lodash": "4.17.10",
-                "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "has-flag": "^3.0.0"
+            }
+        },
+        "table": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+            "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.9.1",
+                "lodash": "^4.17.11",
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.10.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+                    "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
         },
         "taffydb": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
             "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-            "dev": true
-        },
-        "text-encoding": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-            "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
             "dev": true
         },
         "text-table": {
@@ -4866,7 +4887,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "tough-cookie": {
@@ -4874,16 +4895,22 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "requires": {
-                "psl": "1.1.29",
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             }
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "dev": true
         },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -4898,19 +4925,13 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true
-        },
-        "typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
         },
         "underscore": {
@@ -4936,6 +4957,23 @@
                 }
             }
         },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
+                }
+            }
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4952,18 +4990,18 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "which": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "wordwrap": {
@@ -4979,12 +5017,12 @@
             "dev": true
         },
         "write": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+            "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "xmlcreate": {
@@ -4997,12 +5035,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
-        },
-        "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "generate-docs": "node_modules/.bin/jsdoc -c jsdoc.json"
     },
     "dependencies": {
+        "auto-bind": "^2.0.0",
         "jsdoc-template": "git://github.com/braintree/jsdoc-template.git",
         "mkdirp": "^0.5.1",
         "npm": "^6.8.0",
@@ -18,7 +19,7 @@
     "devDependencies": {
         "chai": "^4.2.0",
         "debug": "^3.2.6",
-        "eslint": "^4.18.1",
+        "eslint": "^5.15.3",
         "eslint-config-google": "^0.9.1",
         "ink-docstrap": "^1.3.2",
         "jsdoc": "^3.5.5",


### PR DESCRIPTION
This PR follows my recommendation from https://github.com/voxel51/api-js/issues/16. Now one is free to use class methods as static methods without worrying about `this` bindings!

For example, this now is possible:

```js
let voxel51 = require('.');

async function example() {
  let api = new voxel51.API();
  api.baseURL = 'https://dev.api.voxel51.com/v1';

  let data = await api.listData();

  let promises = data.map(d => api.getDataDetails(d['id']));
  return await Promise.all(promises);
}

example().then(function(info) {
  console.log(info);
});
```