### PR TITLE
Migrating to compute_mode for JobRequests

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -369,8 +369,9 @@ class API {
    * @param {string} jobName - a name for the job
    * @param {boolean} [autoStart=false] - whether to automatically start the
    *   job upon creation
-   * @param {boolean} [useGPU=true] - whether to use GPU resources when
-   *   running the job
+   * @param {boolean} [useGPU=undefined] - whether to use GPU resources when
+   *   running the job. If this flag is not set, GPU is used if the analytic
+   *   supports it
    * @param {Date|string} [ttl=undefined] - a TTL for the job output. If
    *   none is provided, the default TTL is used. If a string is provided, it
    *   must be in ISO 8601 format: 'YYYY-MM-DDThh:mm:ss.sssZ'
@@ -380,7 +381,8 @@ class API {
    * @todo allow jobJSONPath to accept a job JSON object directly
    */
   async uploadJobRequest(
-      jobRequest, jobName, autoStart = false, useGPU = true, ttl = undefined) {
+      jobRequest, jobName, autoStart = false, useGPU = undefined,
+      ttl = undefined) {
     let uri = this.baseURL + '/jobs';
     let formData = {
       'file': {
@@ -392,13 +394,15 @@ class API {
       },
       'job_name': jobName,
       'auto_start': autoStart.toString(),
-      'use_gpu': useGPU.toString(),
     };
+    if (typeof useGPU !== 'undefined') {
+      formData['use_gpu'] = useGPU.toString();
+    }
     if (ttl) {
       if (ttl instanceof Date) {
-        ttl = ttl.toISOString()
+        ttl = ttl.toISOString();
       }
-      formData['job_ttl'] = ttl
+      formData['job_ttl'] = ttl;
     }
     let body = await requests.post(uri, this.header_, {formData: formData});
     return JSON.parse(body).job;

--- a/lib/api.js
+++ b/lib/api.js
@@ -369,9 +369,6 @@ class API {
    * @param {string} jobName - a name for the job
    * @param {boolean} [autoStart=false] - whether to automatically start the
    *   job upon creation
-   * @param {boolean} [useGPU=undefined] - whether to use GPU resources when
-   *   running the job. If this flag is not set, GPU is used if the analytic
-   *   supports it
    * @param {Date|string} [ttl=undefined] - a TTL for the job output. If
    *   none is provided, the default TTL is used. If a string is provided, it
    *   must be in ISO 8601 format: 'YYYY-MM-DDThh:mm:ss.sssZ'
@@ -381,8 +378,7 @@ class API {
    * @todo allow jobJSONPath to accept a job JSON object directly
    */
   async uploadJobRequest(
-      jobRequest, jobName, autoStart = false, useGPU = undefined,
-      ttl = undefined) {
+      jobRequest, jobName, autoStart = false, ttl = undefined) {
     let uri = this.baseURL + '/jobs';
     let formData = {
       'file': {
@@ -395,9 +391,6 @@ class API {
       'job_name': jobName,
       'auto_start': autoStart.toString(),
     };
-    if (typeof useGPU !== 'undefined') {
-      formData['use_gpu'] = useGPU.toString();
-    }
     if (ttl) {
       if (ttl instanceof Date) {
         ttl = ttl.toISOString();

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -59,10 +59,13 @@ class JobRequest extends utils.Serializable {
    * @param {string} analytic - the name of the analytic to run
    * @param {string} [version=null] - the version of the analytic to run.
    *   If not specified, the latest available version is used
+   * @param {boolean} [use_gpu=null] - whether to use GPU resources when
+   *   running the job. By default, CPU is used
    */
-  constructor(analytic, version = null) {
+  constructor(analytic, version = null, use_gpu = null) {
     this.analytic = analytic;
     this.version = version;
+    this.use_gpu = use_gpu;  // serpant_case used because this is serialized
     this.inputs = {};
     this.parameters = {};
     autoBind(this);
@@ -108,7 +111,7 @@ class JobRequest extends utils.Serializable {
    * @returns {JobRequest} a JobRequest instance
    */
   static fromObject(obj) {
-    let jobRequest = new JobRequest(obj.analytic);
+    let jobRequest = new JobRequest(obj.analytic, obj.version, obj.use_gpu);
 
     // Set inputs
     for (var name in obj.inputs) {

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -17,6 +17,15 @@ const utils = require('./utils.js');
 const DATA_ID_FIELD = 'data-id';
 
 /**
+ * Enum describing the possible compute modes of a job.
+ */
+const JobComputeMode = {
+  CPU: 'cpu',
+  GPU: 'gpu',
+  BEST: 'best'
+}
+
+/**
  * Enum describing the possible states of a job.
  */
 const JobState = {
@@ -59,14 +68,14 @@ class JobRequest extends utils.Serializable {
    * @param {string} analytic - the name of the analytic to run
    * @param {string} [version=null] - the version of the analytic to run.
    *   If not specified, the latest available version is used
-   * @param {boolean} [useGPU=null] - whether to use GPU resources when
-   *   running the job. By default, CPU is used
+   * @param {boolean} [computeMode=null] - the JobComputeMode to use for the
+   *   job. By default, JobComputeMode.BEST is used
    */
-  constructor(analytic, version = null, useGPU = null) {
+  constructor(analytic, version = null, computeMode = null) {
     super();
     this.analytic = analytic;
     this.version = version;
-    this.useGPU = useGPU;
+    this.computeMode = computeMode;
     this.inputs = {};
     this.parameters = {};
     autoBind(this);
@@ -112,8 +121,9 @@ class JobRequest extends utils.Serializable {
    * @returns {JobRequest} a JobRequest instance
    */
   static fromObject(obj) {
-    // Note that we use `use_gpu` in the JSON, not `useGPU`
-    let jobRequest = new JobRequest(obj.analytic, obj.version, obj.use_gpu);
+    // Note that we use `compute_mode` in the JSON, not `computeMode`
+    let jobRequest = new JobRequest(
+      obj.analytic, obj.version, obj.compute_mode);
 
     // Set inputs
     for (var name in obj.inputs) {
@@ -146,8 +156,8 @@ class JobRequest extends utils.Serializable {
     if (!utils.isNullOrUndefined(this.version)) {
       attrs.version = 'version';
     }
-    if (!utils.isNullOrUndefined(this.useGPU)) {
-      attrs.useGPU = 'use_gpu';
+    if (!utils.isNullOrUndefined(this.computeMode)) {
+      attrs.computeMode = 'compute_mode';
     }
     attrs.inputs = 'inputs';
     attrs.parameters = 'parameters';

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -66,7 +66,7 @@ class JobRequest extends utils.Serializable {
     super();
     this.analytic = analytic;
     this.version = version;
-    this.use_gpu = useGPU;  // serpant_case because this is serialized directly
+    this.useGPU = useGPU;
     this.inputs = {};
     this.parameters = {};
     autoBind(this);
@@ -112,6 +112,7 @@ class JobRequest extends utils.Serializable {
    * @returns {JobRequest} a JobRequest instance
    */
   static fromObject(obj) {
+    // Note that we use `use_gpu` in the JSON, not `useGPU`
     let jobRequest = new JobRequest(obj.analytic, obj.version, obj.use_gpu);
 
     // Set inputs
@@ -137,6 +138,20 @@ class JobRequest extends utils.Serializable {
     }
 
     return jobRequest;
+  }
+
+  attributes_() {
+    let attrs = {};
+    attrs.analytic = 'analytic';
+    if (!utils.isNullOrUndefined(this.version)) {
+      attrs.version = 'version';
+    }
+    if (!utils.isNullOrUndefined(this.useGPU)) {
+      attrs.useGPU = 'use_gpu';
+    }
+    attrs.inputs = 'inputs';
+    attrs.parameters = 'parameters';
+    return attrs;
   }
 }
 

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -20,9 +20,9 @@ const DATA_ID_FIELD = 'data-id';
  * Enum describing the possible compute modes of a job.
  */
 const JobComputeMode = {
-  CPU: 'cpu',
-  GPU: 'gpu',
-  BEST: 'best'
+  CPU: 'CPU',
+  GPU: 'GPU',
+  BEST: 'BEST'
 }
 
 /**

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -63,6 +63,7 @@ class JobRequest extends utils.Serializable {
    *   running the job. By default, CPU is used
    */
   constructor(analytic, version = null, useGPU = null) {
+    super();
     this.analytic = analytic;
     this.version = version;
     this.use_gpu = useGPU;  // serpant_case because this is serialized directly
@@ -159,6 +160,7 @@ class RemoteDataPath extends utils.Serializable {
    * @throws {RemoteDataPathError} if the instance creation failed
    */
   constructor(dataId = null) {
+    super();
     this.dataId = dataId;
     if (!this.isValid) {
         throw new RemoteDataPathError('Invalid RemoteDataPath')

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -59,13 +59,13 @@ class JobRequest extends utils.Serializable {
    * @param {string} analytic - the name of the analytic to run
    * @param {string} [version=null] - the version of the analytic to run.
    *   If not specified, the latest available version is used
-   * @param {boolean} [use_gpu=null] - whether to use GPU resources when
+   * @param {boolean} [useGPU=null] - whether to use GPU resources when
    *   running the job. By default, CPU is used
    */
-  constructor(analytic, version = null, use_gpu = null) {
+  constructor(analytic, version = null, useGPU = null) {
     this.analytic = analytic;
     this.version = version;
-    this.use_gpu = use_gpu;  // serpant_case used because this is serialized
+    this.use_gpu = useGPU;  // serpant_case because this is serialized directly
     this.inputs = {};
     this.parameters = {};
     autoBind(this);

--- a/lib/query.js
+++ b/lib/query.js
@@ -239,8 +239,8 @@ class JobsQuery extends BaseQuery {
   constructor() {
     super([
       'id', 'name', 'state', 'archived', 'upload_date', 'analytic_id',
-      'auto_start', 'use_gpu', 'start_date', 'completion_date', 'fail_date',
-      'failure_type']);
+      'auto_start', 'compute_mode', 'start_date', 'completion_date',
+      'fail_date', 'failure_type']);
     autoBind(this);
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -251,6 +251,17 @@ function waitForCondition(condition, conditionArgs, sleepTime, maxWaitTime) {
   });
 };
 
+/**
+ * Checks if the given value is null or undefined.
+ *
+ * @instance
+ * @param {object} value - an arbirary value
+ * @returns {boolean} whether the value is null or undefined
+ */
+function isNullOrUndefined(value) {
+  return (value === null) || (typeof value === "undefined");
+}
+
 exports.readJSON = readJSON;
 exports.JSONToStr = JSONToStr;
 exports.writeJSON = writeJSON;
@@ -261,3 +272,4 @@ exports.ExtendableError = ExtendableError;
 exports.NotImplementedError = NotImplementedError;
 exports.APITimeoutError = APITimeoutError;
 exports.waitForCondition = waitForCondition;
+exports.isNullOrUndefined = isNullOrUndefined;


### PR DESCRIPTION
This PR migrates from `use_gpu` to `compute_mode`, and it allows the API itself to be authoritative on how the default `compute_mode` is set, which is desirable for consistency across clients.