### PR TITLE
Various bug fixes

### DIFF
--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -258,7 +258,7 @@ class API {
 
     let body = await requests.post(
       uri, this.header_, {json: true, body: bodyData});
-    return JSON.parse(body).data;
+    return body.data;
   }
 
   /**

--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -258,6 +258,8 @@ class API {
 
     let body = await requests.post(
       uri, this.header_, {json: true, body: bodyData});
+    // the {json: true} option appears to auto-parse the response body
+    // so no manual parsing is necessary here!
     return body.data;
   }
 

--- a/lib/users/jobs.js
+++ b/lib/users/jobs.js
@@ -237,7 +237,7 @@ class RemoteDataPath extends utils.Serializable {
    */
   static fromObject(obj) {
     if (DATA_ID_FIELD in obj) {
-      return new RemoteDataPath.fromDataId(obj[DATA_ID_FIELD]);
+      return RemoteDataPath.fromDataId(obj[DATA_ID_FIELD]);
     }
     throw new RemoteDataPathError(
       'Invalid RemoteDataPath object: ' + JSON.stringify(obj, null, 4));
@@ -258,6 +258,7 @@ class RemoteDataPath extends utils.Serializable {
  */
 class RemoteDataPathError extends utils.ExtendableError {}
 
+exports.JobComputeMode = JobComputeMode;
 exports.JobState = JobState;
 exports.JobFailureType = JobFailureType;
 exports.JobExecutionError = JobExecutionError;


### PR DESCRIPTION
1) `requests` already parsed the response body to JSON prior to manual attempt
2) `RemoteDataPath.fromDataId()` is not a constructor function, removed `new`
3) `JobComputeMode` was not exported from respective file