### PR TITLE
Parsing base API URL from token, if possible

### DIFF
--- a/lib/apps/api.js
+++ b/lib/apps/api.js
@@ -11,6 +11,7 @@
 
 const autoBind = require('auto-bind');
 const fs = require('fs');
+const urljoin = require('url-join');
 
 const api = require('../users/api.js');
 const auth = require('./auth.js');
@@ -97,7 +98,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async listAnalytics(allVersions=false) {
-    let uri = this.baseURL + '/apps/analytics/list';
+    let uri = urljoin(this.baseURL, 'apps', 'analytics', 'list');
     let params = {all_versions: allVersions};
     let body = await requests.get(uri, this.header_, {qs: params});
     return JSON.parse(body).analytics;
@@ -114,7 +115,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async queryAnalytics(analyticsQuery) {
-    let uri = this.baseURL + '/apps/analytics';
+    let uri = urljoin(this.baseURL, 'apps', 'analytics');
     let body = await requests.get(
       uri, this.header_, {qs: analyticsQuery.toObject()});
     return JSON.parse(body);
@@ -129,7 +130,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getAnalyticDoc(analyticId) {
-    let uri = this.baseURL + '/apps/analytics/' + analyticId;
+    let uri = urljoin(this.baseURL, 'apps', 'analytics', analyticId);
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body);
   }
@@ -150,7 +151,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async uploadAnalytic(docJSONPath, analyticType=undefined) {
-    let uri = this.baseURL + '/apps/analytics';
+    let uri = urljoin(this.baseURL, 'apps', 'analytics');
     let formData = {
       file: fs.createReadStream(docJSONPath),
     };
@@ -177,7 +178,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async uploadAnalyticImage(analyticId, imageTarPath, imageType) {
-    let uri = this.baseURL + '/apps/analytics/' + analyticId + '/images';
+    let uri = urljoin(this.baseURL, 'apps', 'analytics', analyticId, 'images');
     let formData = {
       file: fs.createReadStream(imageTarPath),
     };
@@ -194,7 +195,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async deleteAnalytic(analyticId) {
-    let uri = this.baseURL + '/apps/analytics/' + analyticId;
+    let uri = urljoin(this.baseURL, 'apps', 'analytics', analyticId);
     await requests.delete(uri, this.header_);
   }
 
@@ -213,7 +214,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async queryApplicationData(dataQuery) {
-    let uri = this.baseURL + '/apps/data';
+    let uri = urljoin(this.baseURL, 'apps', 'data');
     let body = await requests.get(
       uri, this.header_, {qs: dataQuery.toObject()});
     return JSON.parse(body);
@@ -234,7 +235,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async queryApplicationJobs(jobsQuery) {
-    let uri = this.baseURL + '/apps/jobs';
+    let uri = urljoin(this.baseURL, 'apps', 'jobs');
     let body = await requests.get(
       uri, this.header_, {qs: jobsQuery.toObject()});
     return JSON.parse(body);
@@ -250,7 +251,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async createUser(username) {
-    let uri = this.baseURL + '/apps/users';
+    let uri = urljoin(this.baseURL, 'apps', 'users');
     await requests.post(uri, this.header_, {json: true, body: {username}});
   }
 
@@ -262,7 +263,7 @@ class ApplicationAPI extends api.API {
    * @throws {APIError} if the request was unsuccessful
    */
   async listUsers() {
-    let uri = this.baseURL + '/apps/users/list';
+    let uri = urljoin(this.baseURL, 'apps', 'users', 'list');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).users;
   }
@@ -275,7 +276,7 @@ class ApplicationAPI extends api.API {
    * @return {Object} an object describing the status of the platform
    */
   async getPlatformStatus() {
-    let uri = this.baseURL + '/apps/status/all';
+    let uri = urljoin(this.baseURL, 'apps', 'status', 'all');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).statuses;
   }

--- a/lib/apps/auth.js
+++ b/lib/apps/auth.js
@@ -12,7 +12,6 @@
 const autoBind = require('auto-bind');
 const fs = require('fs');
 const os = require('os');
-const path = require('path');
 
 const auth = require('../users/auth.js');
 const utils = require('../users/utils.js');

--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -11,6 +11,7 @@
 
 const autoBind = require('auto-bind');
 const fs = require('fs');
+const urljoin = require('url-join');
 
 const auth = require('./auth.js');
 const jobs = require('./jobs.js');
@@ -74,7 +75,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async listAnalytics(allVersions=false) {
-    let uri = this.baseURL + '/analytics/list';
+    let uri = urljoin(this.baseURL, 'analytics', 'list');
     let params = {all_versions: allVersions};
     let body = await requests.get(uri, this.header_, {qs: params});
     return JSON.parse(body).analytics;
@@ -91,7 +92,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async queryAnalytics(analyticsQuery) {
-    let uri = this.baseURL + '/analytics';
+    let uri = urljoin(this.baseURL, 'analytics');
     let body = await requests.get(
       uri, this.header_, {qs: analyticsQuery.toObject()});
     return JSON.parse(body);
@@ -106,7 +107,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getAnalyticDoc(analyticId) {
-    let uri = this.baseURL + '/analytics/' + analyticId;
+    let uri = urljoin(this.baseURL, 'analytics', analyticId);
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body);
   }
@@ -127,7 +128,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async uploadAnalytic(docJSONPath, analyticType=undefined) {
-    let uri = this.baseURL + '/analytics';
+    let uri = urljoin(this.baseURL, 'analytics');
     let formData = {
       file: fs.createReadStream(docJSONPath),
     };
@@ -154,7 +155,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async uploadAnalyticImage(analyticId, imageTarPath, imageType) {
-    let uri = this.baseURL + '/analytics/' + analyticId + '/images';
+    let uri = urljoin(this.baseURL, 'analytics', analyticId, 'images');
     let formData = {
       file: fs.createReadStream(imageTarPath),
     };
@@ -171,7 +172,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async deleteAnalytic(analyticId) {
-    let uri = this.baseURL + '/analytics/' + analyticId;
+    let uri = urljoin(this.baseURL, 'analytics', analyticId);
     await requests.delete(uri, this.header_);
   }
 
@@ -185,7 +186,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async listData() {
-    let uri = this.baseURL + '/data/list';
+    let uri = urljoin(this.baseURL, 'data', 'list');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).data;
   }
@@ -201,7 +202,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async queryData(dataQuery) {
-    let uri = this.baseURL + '/data';
+    let uri = urljoin(this.baseURL, 'data');
     let body = await requests.get(
       uri, this.header_, {qs: dataQuery.toObject()});
     return JSON.parse(body);
@@ -228,7 +229,7 @@ class API {
       }
       formData['data_ttl'] = ttl;
     }
-    let uri = this.baseURL + '/data';
+    let uri = urljoin(this.baseURL, 'data');
     let body = await requests.post(uri, this.header_, {formData: formData});
     return JSON.parse(body).data;
   }
@@ -256,7 +257,7 @@ class API {
    */
   async postDataAsURL(
       url, filename, mimeType, size, encoding=undefined, ttl=undefined) {
-    let uri = this.baseURL + '/data/url';
+    let uri = urljoin(this.baseURL, 'data', 'url');
     let bodyData = {
       signed_url: url,
       filename: filename,
@@ -289,7 +290,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getDataDetails(dataId) {
-    let uri = this.baseURL + '/data/' + dataId;
+    let uri = urljoin(this.baseURL, 'data', dataId);
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).data;
   }
@@ -313,7 +314,7 @@ class API {
     let stream = fs.createWriteStream(outputPath);
     stream.on('error', function(err) { throw err; });
     stream.on('end', function() { return; });
-    let uri = this.baseURL + '/data/' + dataId + '/download';
+    let uri = urljoin(this.baseURL, 'data', dataId, 'download');
     return await requests.pipe(uri, stream, this.header_);
   }
 
@@ -326,7 +327,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getDataDownloadURL(dataId) {
-    let uri = this.baseURL + '/data/' + dataId + '/download-url';
+    let uri = urljoin(this.baseURL, 'data', dataId, 'download-url');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).url;
   }
@@ -345,7 +346,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async updateDataTTL(dataId, days) {
-    let uri = this.baseURL + '/data/' + dataId + '/ttl';
+    let uri = urljoin(this.baseURL, 'data', dataId, 'ttl');
     let formData = {'days': days.toString()};
     await requests.put(uri, this.header_, {form: formData});
   }
@@ -358,7 +359,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async deleteData(dataId) {
-    let uri = this.baseURL + '/data/' + dataId;
+    let uri = urljoin(this.baseURL, 'data', dataId);
     await requests.delete(uri, this.header_);
   }
 
@@ -372,7 +373,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async listJobs() {
-    let uri = this.baseURL + '/jobs/list';
+    let uri = urljoin(this.baseURL, 'jobs', 'list');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).jobs;
   }
@@ -388,7 +389,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async queryJobs(jobsQuery) {
-    let uri = this.baseURL + '/jobs';
+    let uri = urljoin(this.baseURL, 'jobs');
     let body = await requests.get(
       uri, this.header_, {qs: jobsQuery.toObject()});
     return JSON.parse(body);
@@ -411,7 +412,7 @@ class API {
    * @todo allow jobJSONPath to accept a job JSON object directly
    */
   async uploadJobRequest(jobRequest, jobName, autoStart=false, ttl=undefined) {
-    let uri = this.baseURL + '/jobs';
+    let uri = urljoin(this.baseURL, 'jobs');
     let formData = {
       'file': {
         value: jobRequest.toString(),
@@ -442,7 +443,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getJobDetails(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId;
+    let uri = urljoin(this.baseURL, 'jobs', jobId);
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).job;
   }
@@ -456,7 +457,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getJobRequest(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/request';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'request');
     let body = await requests.get(uri, this.header_);
     return jobs.JobRequest.fromString(body);
   }
@@ -469,7 +470,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async startJob(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/start';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'start');
     await requests.put(uri, this.header_);
   }
 
@@ -487,7 +488,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async updateJobTTL(jobId, days) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/ttl';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'ttl');
     let formData = {'days': days.toString()};
     await requests.put(uri, this.header_, {form: formData});
   }
@@ -500,7 +501,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async archiveJob(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/archive';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'archive');
     await requests.put(uri, this.header_);
   }
 
@@ -512,7 +513,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async unarchiveJob(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/unarchive';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'unarchive');
     await requests.put(uri, this.header_);
   }
 
@@ -618,7 +619,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getJobStatus(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/status';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'status');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body);
   }
@@ -635,7 +636,7 @@ class API {
     let stream = fs.createWriteStream(outputPath);
     stream.on('error', function(error) { throw error; });
     stream.on('end', function() { return; });
-    let uri = this.baseURL + '/jobs/' + jobId + '/output';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'output');
     await requests.pipe(uri, stream, this.header_);
   }
 
@@ -648,7 +649,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getJobOutputDownloadURL(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/output-url';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'output-url');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).url;
   }
@@ -673,7 +674,7 @@ class API {
     let stream = fs.createWriteStream(outputPath);
     stream.on('error', function(error) { throw error; });
     stream.on('end', function() { return; });
-    let uri = this.baseURL + '/jobs/' + jobId + '/log';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'log');
     await requests.pipe(uri, stream, this.header_);
   }
 
@@ -690,7 +691,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async getJobLogfileDownloadURL(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/log-url';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'log-url');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).url;
   }
@@ -705,7 +706,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async deleteJob(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId;
+    let uri = urljoin(this.baseURL, 'jobs', jobId);
     await requests.delete(uri, this.header_);
   }
 
@@ -719,7 +720,7 @@ class API {
    * @throws {APIError} if the request was unsuccessful
    */
   async killJob(jobId) {
-    let uri = this.baseURL + '/jobs/' + jobId + '/kill';
+    let uri = urljoin(this.baseURL, 'jobs', jobId, 'kill');
     await requests.put(uri, this.header_);
   }
 
@@ -731,7 +732,7 @@ class API {
    * @return {Object} an object describing the status of the platform
    */
   async getPlatformStatus() {
-    let uri = this.baseURL + '/status/all';
+    let uri = urljoin(this.baseURL, 'status', 'all');
     let body = await requests.get(uri, this.header_);
     return JSON.parse(body).statuses;
   }

--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -17,8 +17,6 @@ const jobs = require('./jobs.js');
 const requests = require('./requests.js');
 const utils = require('./utils.js');
 
-const BASE_URL_ = 'https://api.voxel51.com/v1';
-
 /**
  * Enum describing the possible types of analytics.
  *
@@ -44,9 +42,12 @@ class API {
    *   loaded from `~/.voxel51/api-token.json`
    */
   constructor(token=null) {
-    this.baseURL = BASE_URL_;
-    this.token = token || auth.loadToken();
-    this.header_ = this.token.getHeader();
+    if (!token) {
+      token = auth.loadToken();
+    }
+    this.baseURL = urljoin(token.baseAPIURL, 'v1');
+    this.token = token;
+    this.header_ = token.getHeader();
     autoBind(this);
   }
 

--- a/lib/users/auth.js
+++ b/lib/users/auth.js
@@ -12,7 +12,6 @@
 const autoBind = require('auto-bind');
 const fs = require('fs');
 const os = require('os');
-const path = require('path');
 
 const utils = require('./utils.js');
 
@@ -110,9 +109,11 @@ class Token {
    * @retuns {Token} a Token instance
    */
   constructor(token) {
-    this.creationDate = token.access_token.created_at;
-    this.id = token.access_token.token_id;
-    this.privateKey_ = token.access_token.private_key;
+    let accessToken = token.access_token;
+    this.baseAPIURL = Token.parseBaseAPIURL_(accessToken);
+    this.creationDate = accessToken.created_at;
+    this.id = accessToken.token_id;
+    this.privateKey_ = accessToken.private_key;
     this.token_ = token;
     autoBind(this);
   }
@@ -143,6 +144,17 @@ class Token {
    */
   static fromJSON(path) {
     return new Token(utils.readJSON(path));
+  }
+
+  static parseBaseAPIURL_(accessToken) {
+    let baseAPIURL = accessToken.base_api_url;
+    if (!baseAPIURL) {
+      baseAPIURL = 'https://api.voxel51.com';
+      console.warn(
+        `No base API URL found in token; defaulting to '${baseAPIURL}'. To ` +
+        `resolve this message, download a new API token from the Platform`);
+    }
+    return baseAPIURL;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5018,6 +5018,11 @@
                 }
             }
         },
+        "url-join": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "mkdirp": "^0.5.1",
         "npm": "^6.11.3",
         "qs": "^6.6.0",
-        "request": "^2.88.0"
+        "request": "^2.88.0",
+        "url-join": "^4.0.1"
     },
     "devDependencies": {
         "chai": "^4.2.0",


### PR DESCRIPTION
This is backwards compatible. Folks who are not lucky enough to have a base URL in their tokens will get a warning message suggesting that they download a new API token from their friendly local Platform.