### PR TITLE
Fix missing path module imports

### DIFF
--- a/lib/apps/auth.js
+++ b/lib/apps/auth.js
@@ -12,6 +12,7 @@
 const autoBind = require('auto-bind');
 const fs = require('fs');
 const os = require('os');
+const path = require('path');
 
 const auth = require('../users/auth.js');
 const utils = require('../users/utils.js');

--- a/lib/users/auth.js
+++ b/lib/users/auth.js
@@ -12,6 +12,7 @@
 const autoBind = require('auto-bind');
 const fs = require('fs');
 const os = require('os');
+const path = require('path');
 
 const utils = require('./utils.js');
 


### PR DESCRIPTION
Needed for standalone scripts
(broke in https://github.com/voxel51/api-js/commit/dc0c57016b1c4855417f0d8624301975d1547b1f)