### PR TITLE
Adding output_filename to support job query fields

### DIFF
--- a/lib/users/query.js
+++ b/lib/users/query.js
@@ -282,7 +282,7 @@ class JobsQuery extends BaseQuery {
     super([
       'id', 'name', 'state', 'archived', 'upload_date', 'analytic_id',
       'auto_start', 'compute_mode', 'start_date', 'completion_date',
-      'fail_date', 'failure_type', 'expiration_date']);
+      'fail_date', 'failure_type', 'expiration_date', 'output_filename']);
     autoBind(this);
   }
 }


### PR DESCRIPTION
`api.getJobDetails()` returns `output_filename`, so this needs to be supported for job queries as well.

Cannot be merged until server-side support for including `output_filename` in job queries is supported.

Python: https://github.com/voxel51/api-py/pull/69