### PR TITLE
Validate search fields client-side

### DIFF
--- a/lib/users/query.js
+++ b/lib/users/query.js
@@ -12,6 +12,8 @@
 const autoBind = require('auto-bind');
 const qs = require('qs');
 
+const requests = require('./requests.js');
+
 /**
  * Base class for API queries.
  *
@@ -83,9 +85,10 @@ class BaseQuery {
    * @return {BaseQuery} the updated query instance
    */
   addSearch(field, searchStr) {
-    if (this.isSupportedField_(field)) {
-      this.search.push(`${field}:${searchStr}`);
+    if (!this.isSupportedField_(field)) {
+      throw new requests.APIError('Invalid search parameter ' + field, 400);
     }
+    this.search.push(`${field}:${searchStr}`);
     return this;
   }
 


### PR DESCRIPTION
This was previously discarding invalid search fields silently

Python: https://github.com/voxel51/api-py/pull/78