### PR TITLE
Adding support for setting token private key via environment variable

### DIFF
--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -39,8 +39,15 @@ variable in your shell to point to your API token file:
 export VOXEL51_APP_TOKEN=/path/to/your/app-token.json
 ```
 
-Alternatively, you can permanently activate an application token by executing
-the following commands:
+Alternatively, you can directly set the `VOXEL51_APP_PRIVATE_KEY` environment
+variable in your shell to the private key of your API token:
+
+```shell
+export VOXEL51_APP_PRIVATE_KEY=XXXXXXXX
+```
+
+Finally, you can permanently activate an application token by executing the
+following commands:
 
 ```js
 let voxel51 = require('.');

--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ to your API token file:
 export VOXEL51_API_TOKEN=/path/to/your/api-token.json
 ```
 
-Alternatively, you can permanently activate a token by executing the following
+Alternatively, you can directly set the `VOXEL51_API_PRIVATE_KEY` environment
+variable in your shell to the private key of your API token:
+
+```shell
+export VOXEL51_API_PRIVATE_KEY=XXXXXXXX
+```
+
+Finally, you can permanently activate a token by executing the following
 commands:
 
 ```js

--- a/lib/apps/api.js
+++ b/lib/apps/api.js
@@ -26,6 +26,16 @@ const requests = require('../users/requests.js');
  * regular platform users. In order to use these user-specific methods,
  * however, you must first activate a user via ApplicationAPI.with_user.
  *
+ * Using this API requires a valid application token. The following strategy is
+ * used to locate your active application token:
+ *
+ * (1) Use the ApplicationToken provided when constructing the ApplicationAPI
+ *     instance
+ * (2) Use the `VOXEL51_APP_PRIVATE_KEY` and `VOXEL51_APP_BASE_URL` environment
+ *     variables
+ * (3) Use the `VOXEL51_APP_TOKEN` environment variable
+ * (4) Load the active token from `~/.voxel51/app-token.json`
+ *
  * @extends module:users/api~API
  */
 class ApplicationAPI extends api.API {
@@ -34,9 +44,8 @@ class ApplicationAPI extends api.API {
    *
    * @constructor
    * @param {string} [token=null] - an optional ApplicationToken to use. If no
-   *   token is provided, the `VOXEL51_APP_TOKEN` environment variable is
-   *   checked and, if set, the token is loaded from that path. Otherwise, the
-   *   token is loaded from `~/.voxel51/app-token.json`
+   *   token is provided, the strategy described above is used to locate the
+   *   active token
    */
   constructor(token=null) {
     token = token || auth.loadApplicationToken();

--- a/lib/apps/api.js
+++ b/lib/apps/api.js
@@ -27,7 +27,7 @@ const requests = require('../users/requests.js');
  * however, you must first activate a user via ApplicationAPI.with_user.
  *
  * Using this API requires a valid application token. The following strategy is
- * used to locate your active application token:
+ * used to locate your active application token (in order of precedence):
  *
  * (1) Use the ApplicationToken provided when constructing the ApplicationAPI
  *     instance

--- a/lib/apps/auth.js
+++ b/lib/apps/auth.js
@@ -86,7 +86,8 @@ function getActiveApplicationTokenPath() {
 /**
  * Loads the active application token.
  *
- * The following strategy is used to locate your active application token:
+ * The following strategy is used to locate your active application token (in
+ * order of precedence):
  *
  * (1) Use the provided `tokenPath`
  * (2) Use the `VOXEL51_APP_PRIVATE_KEY` and `VOXEL51_APP_BASE_URL` environment

--- a/lib/apps/auth.js
+++ b/lib/apps/auth.js
@@ -120,6 +120,7 @@ function loadApplicationToken(tokenPath=null) {
   throw new ApplicationTokenError('No application token found');
 }
 
+// eslint-disable-next-line require-jsdoc
 function loadApplicationTokenFromPath_(tokenPath) {
   if (!fs.existsSync(tokenPath)) {
     throw new ApplicationTokenError(`No file found at '${tokenPath}'`);

--- a/lib/apps/auth.js
+++ b/lib/apps/auth.js
@@ -21,6 +21,8 @@ const TOKEN_ENV_VAR = 'VOXEL51_APP_TOKEN';
 const PRIVATE_KEY_ENV_VAR = 'VOXEL51_APP_PRIVATE_KEY';
 const BASE_API_URL_ENV_VAR = 'VOXEL51_APP_BASE_URL';
 
+const DEFAULT_BASE_API_URL = 'https://api.voxel51.com';
+
 const KEY_HEADER = 'x-voxel51-application';
 const USER_HEADER = 'x-voxel51-application-user';
 const TOKEN_PATH = path.join(os.homedir(), '.voxel51', 'app-token.json');
@@ -174,6 +176,23 @@ class ApplicationToken extends auth.Token {
    */
   static fromJSON(path) {
     return new ApplicationToken(utils.readJSON(path));
+  }
+
+  /**
+   * Builds a ApplicationToken from its private key.
+   *
+   * @param {string} privateKey - the private key of the token
+   * @param {string} [baseAPIURL=null] - the base URL of the API for the token.
+   *   If undefined, the default platform API is assumed
+   * @return {ApplicationToken} an ApplicationToken instance
+   */
+  static fromPrivateKey(privateKey, baseAPIURL=undefined) {
+    return new ApplicationToken({
+      access_token: {
+        private_key: privateKey,
+        base_api_url: baseAPIURL || DEFAULT_BASE_API_URL,
+      },
+    });
   }
 }
 

--- a/lib/apps/auth.js
+++ b/lib/apps/auth.js
@@ -17,7 +17,10 @@ const path = require('path');
 const auth = require('../users/auth.js');
 const utils = require('../users/utils.js');
 
-const TOKEN_ENVIRON_VAR = 'VOXEL51_APP_TOKEN';
+const TOKEN_ENV_VAR = 'VOXEL51_APP_TOKEN';
+const PRIVATE_KEY_ENV_VAR = 'VOXEL51_APP_PRIVATE_KEY';
+const BASE_API_URL_ENV_VAR = 'VOXEL51_APP_BASE_URL';
+
 const KEY_HEADER = 'x-voxel51-application';
 const USER_HEADER = 'x-voxel51-application-user';
 const TOKEN_PATH = path.join(os.homedir(), '.voxel51', 'app-token.json');
@@ -47,47 +50,77 @@ function deactivateApplicationToken() {
 }
 
 /**
- * Gets the path to the active application token.
+ * Gets the path to the active application token, if any.
  *
  * If the `VOXEL51_APP_TOKEN` environment variable is set, that path is used.
  * Otherwise, `~/.voxel51/app-token.json` is used.
  *
+ * Note that if the `VOXEL51_APP_PRIVATE_KEY` environment variable is set, this
+ * function will always return `undefined`, since that environment variable
+ * always takes precedence over other methods for locating the active token.
+ *
  * @instance
- * @return {string} the path to the active application token
- * @throws {ApplicationTokenError} if no application token was found
+ * @return {string} the path to the active application token, or undefined
  */
 function getActiveApplicationTokenPath() {
-  let tokenPath = process.env[TOKEN_ENVIRON_VAR];
+  let privateKey = process.env[PRIVATE_KEY_ENV_VAR];
+  if (privateKey) {
+    return;
+  }
+
+  let tokenPath = process.env[TOKEN_ENV_VAR];
   if (tokenPath) {
     if (!fs.existsSync(tokenPath)) {
       throw new ApplicationTokenError(
-        `No application token found at '${TOKEN_ENVIRON_VAR}=${tokenPath}'`);
+        `No file found at '${TOKEN_ENV_VAR}=${tokenPath}'`);
     }
   } else if (fs.existsSync(TOKEN_PATH)) {
     tokenPath = TOKEN_PATH;
-  } else {
-    throw new ApplicationTokenError('No application token found');
   }
+
   return tokenPath;
 }
 
 /**
  * Loads the active application token.
  *
+ * The following strategy is used to locate your active application token:
+ *
+ * (1) Use the provided `tokenPath`
+ * (2) Use the `VOXEL51_APP_PRIVATE_KEY` and `VOXEL51_APP_BASE_URL` environment
+ *     variables
+ * (3) Use the `VOXEL51_APP_TOKEN` environment variable
+ * (4) Load the active token from `~/.voxel51/app-token.json`
+ *
  * @instance
  * @param {string} [tokenPath=null] - optional path to an ApplicationToken JSON
- *   file. If no path is provided as an argument, the `VOXEL51_APP_TOKEN`
- *   environment variable is checked and, if set, the token is loaded from that
- *   path. Otherwise, the token is loaded from `~/.voxel51/app-token.json`
+ *   file. If no path is provided as an argument, the active token is loaded
+ *   using the strategy described above
  * @return {ApplicationToken} the active application token
  * @throws {ApplicationTokenError} if no valid application token was found
  */
 function loadApplicationToken(tokenPath=null) {
-  if (!tokenPath) {
-    tokenPath = getActiveApplicationTokenPath();
-  } else if (!fs.existsSync(tokenPath)) {
-    throw new ApplicationTokenError(
-      `No application token found at '${tokenPath}'`);
+  if (tokenPath) {
+    return loadApplicationTokenFromPath_(tokenPath);
+  }
+
+  let privateKey = process.env[PRIVATE_KEY_ENV_VAR];
+  if (privateKey) {
+    let baseAPIURL = process.env[BASE_API_URL_ENV_VAR];
+    return ApplicationToken.fromPrivateKey(privateKey, baseAPIURL);
+  }
+
+  tokenPath = getActiveApplicationTokenPath();
+  if (tokenPath) {
+    return loadApplicationTokenFromPath_(tokenPath);
+  }
+
+  throw new ApplicationTokenError('No application token found');
+}
+
+function loadApplicationTokenFromPath_(tokenPath) {
+  if (!fs.existsSync(tokenPath)) {
+    throw new ApplicationTokenError(`No file found at '${tokenPath}'`);
   }
 
   try {
@@ -126,7 +159,7 @@ class ApplicationToken extends auth.Token {
    * @return {object} a header object
    */
   getHeader(username=null) {
-    let header = {[KEY_HEADER]: this.privateKey_};
+    let header = {[KEY_HEADER]: this.privateKey};
     if (username) {
       header[USER_HEADER] = username;
     }

--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -44,7 +44,7 @@ const AnalyticImageType = {
  * Main class for managing a session with the Voxel51 Platform API.
  *
  * Using this API requires a valid API token. The following strategy is used to
- * locate your active API token:
+ * locate your active API token (in order of precedence):
  *
  * (1) Use the Token provided when constructing the API instance
  * (2) Use the `VOXEL51_API_PRIVATE_KEY` and `VOXEL51_API_BASE_URL` environment

--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -42,6 +42,15 @@ const AnalyticImageType = {
 
 /**
  * Main class for managing a session with the Voxel51 Platform API.
+ *
+ * Using this API requires a valid API token. The following strategy is used to
+ * locate your active API token:
+ *
+ * (1) Use the Token provided when constructing the API instance
+ * (2) Use the `VOXEL51_API_PRIVATE_KEY` and `VOXEL51_API_BASE_URL` environment
+ *     variables
+ * (3) Use the `VOXEL51_API_TOKEN` environment variable
+ * (4) Load the active token from `~/.voxel51/api-token.json`
  */
 class API {
   /**
@@ -49,9 +58,8 @@ class API {
    *
    * @constructor
    * @param {string} [token=null] - an optional Token to use. If no token is
-   *   provided, the `VOXEL51_API_TOKEN` environment variable is checked and,
-   *   if set, the token is loaded from that path. Otherwise, the token is
-   *   loaded from `~/.voxel51/api-token.json`
+   *   provided, the strategy described above is used to locate the active
+   *   token
    */
   constructor(token=null) {
     if (!token) {

--- a/lib/users/auth.js
+++ b/lib/users/auth.js
@@ -186,6 +186,8 @@ class Token {
    * Builds a Token from its private key.
    *
    * @param {string} privateKey - the private key of the token
+   * @param {string} [baseAPIURL=null] - the base URL of the API for the token.
+   *   If undefined, the default platform API is assumed
    * @return {Token} a Token instance
    */
   static fromPrivateKey(privateKey, baseAPIURL=undefined) {
@@ -193,7 +195,7 @@ class Token {
       access_token: {
         private_key: privateKey,
         base_api_url: baseAPIURL || DEAFULT_BASE_API_URL,
-      }
+      },
     });
   }
 

--- a/lib/users/auth.js
+++ b/lib/users/auth.js
@@ -17,8 +17,13 @@ const path = require('path');
 
 const utils = require('./utils.js');
 
-const TOKEN_ENVIRON_VAR = 'VOXEL51_API_TOKEN';
+const TOKEN_ENV_VAR = 'VOXEL51_API_TOKEN';
+const PRIVATE_KEY_ENV_VAR = 'VOXEL51_API_PRIVATE_KEY';
+const BASE_API_URL_ENV_VAR = 'VOXEL51_API_BASE_URL';
+
 const TOKEN_PATH = path.join(os.homedir(), '.voxel51', 'api-token.json');
+
+const DEAFULT_BASE_API_URL = 'https://api.voxel51.com';
 const HELP_URL = 'https://voxel51.com/docs/api/?javascript#authentication';
 
 /**
@@ -49,46 +54,76 @@ function deactivateToken() {
 }
 
 /**
- * Gets the path to the active API token.
+ * Gets the path to the active API token, if any.
  *
  * If the `VOXEL51_API_TOKEN` environment variable is set, that path is used.
  * Otherwise, `~/.voxel51/api-token.json` is used.
  *
+ * Note that if the `VOXEL51_API_PRIVATE_KEY` environment variable is set, this
+ * function will always return `undefined`, since that environment variable
+ * always takes precedence over other methods for locating the active token.
+ *
  * @instance
- * @return {string} the path to the active token
- * @throws {TokenError} if no token was found
+ * @return {string} the path to the active token, or undefined
  */
 function getActiveTokenPath() {
-  let tokenPath = process.env[TOKEN_ENVIRON_VAR];
+  let privateKey = process.env[PRIVATE_KEY_ENV_VAR];
+  if (privateKey) {
+    return;
+  }
+
+  let tokenPath = process.env[TOKEN_ENV_VAR];
   if (tokenPath) {
     if (!fs.existsSync(tokenPath)) {
-      throw new TokenError(
-        `No API token found at '${TOKEN_ENVIRON_VAR}=${tokenPath}'`);
+      throw new TokenError(`No file found at '${TOKEN_ENV_VAR}=${tokenPath}'`);
     }
   } else if (fs.existsSync(TOKEN_PATH)) {
     tokenPath = TOKEN_PATH;
-  } else {
-    throw new TokenError('No API token found');
   }
+
   return tokenPath;
 }
 
 /**
  * Loads the active API token.
  *
+ * The following strategy is used to locate your active API token:
+ *
+ * (1) Use the provided `tokenPath`
+ * (2) Use the `VOXEL51_API_PRIVATE_KEY` and `VOXEL51_API_BASE_URL` environment
+ *     variables
+ * (3) Use the `VOXEL51_API_TOKEN` environment variable
+ * (4) Load the active token from `~/.voxel51/api-token.json`
+ *
  * @instance
  * @param {string} [tokenPath=null] - optional path to a Token JSON file.
- *   If no path is provided as an argument, the `VOXEL51_API_TOKEN` environment
- *   variable is checked and, if set, the token is loaded from that path.
- *   Otherwise, the token is loaded from `~/.voxel51/api-token.json`
+ *   If no path is provided, the active token is loaded using the strategy
+ *   described above
  * @return {Token} the active API token
  * @throws {TokenError} if no valid token was found
  */
 function loadToken(tokenPath=null) {
-  if (!tokenPath) {
-    tokenPath = getActiveTokenPath();
-  } else if (!fs.existsSync(tokenPath)) {
-    throw new TokenError(`No API token found at '${tokenPath}'`);
+  if (tokenPath) {
+    return loadTokenFromPath_(tokenPath);
+  }
+
+  let privateKey = process.env[PRIVATE_KEY_ENV_VAR];
+  if (privateKey) {
+    let baseAPIURL = process.env[BASE_API_URL_ENV_VAR];
+    return Token.fromPrivateKey(privateKey, baseAPIURL);
+  }
+
+  tokenPath = getActiveTokenPath();
+  if (tokenPath) {
+    return loadTokenFromPath_(tokenPath);
+  }
+
+  throw new TokenError('No API token found');
+}
+
+function loadTokenFromPath_(tokenPath) {
+  if (!fs.existsSync(tokenPath)) {
+    throw new TokenError(`No file found at '${tokenPath}'`);
   }
 
   try {
@@ -114,7 +149,7 @@ class Token {
     this.baseAPIURL = Token.parseBaseAPIURL_(accessToken);
     this.creationDate = accessToken.created_at;
     this.id = accessToken.token_id;
-    this.privateKey_ = accessToken.private_key;
+    this.privateKey = accessToken.private_key;
     this.token_ = token;
     autoBind(this);
   }
@@ -134,7 +169,7 @@ class Token {
    * @return {object} a header object
    */
   getHeader() {
-    return {'Authorization': 'Bearer ' + this.privateKey_};
+    return {'Authorization': 'Bearer ' + this.privateKey};
   }
 
   /**
@@ -147,11 +182,26 @@ class Token {
     return new Token(utils.readJSON(path));
   }
 
+  /**
+   * Builds a Token from its private key.
+   *
+   * @param {string} privateKey - the private key of the token
+   * @return {Token} a Token instance
+   */
+  static fromPrivateKey(privateKey, baseAPIURL=undefined) {
+    return new Token({
+      access_token: {
+        private_key: privateKey,
+        base_api_url: baseAPIURL || DEAFULT_BASE_API_URL,
+      }
+    });
+  }
+
   // eslint-disable-next-line require-jsdoc
   static parseBaseAPIURL_(accessToken) {
     let baseAPIURL = accessToken.base_api_url;
     if (!baseAPIURL) {
-      baseAPIURL = 'https://api.voxel51.com';
+      baseAPIURL = DEAFULT_BASE_API_URL;
       console.warn(
         `No base API URL found in token; defaulting to '${baseAPIURL}'. To ` +
         `resolve this message, download a new API token from the Platform`);

--- a/lib/users/auth.js
+++ b/lib/users/auth.js
@@ -87,7 +87,8 @@ function getActiveTokenPath() {
 /**
  * Loads the active API token.
  *
- * The following strategy is used to locate your active API token:
+ * The following strategy is used to locate your active API token (in order of
+ * precedence):
  *
  * (1) Use the provided `tokenPath`
  * (2) Use the `VOXEL51_API_PRIVATE_KEY` and `VOXEL51_API_BASE_URL` environment

--- a/lib/users/auth.js
+++ b/lib/users/auth.js
@@ -23,7 +23,7 @@ const BASE_API_URL_ENV_VAR = 'VOXEL51_API_BASE_URL';
 
 const TOKEN_PATH = path.join(os.homedir(), '.voxel51', 'api-token.json');
 
-const DEAFULT_BASE_API_URL = 'https://api.voxel51.com';
+const DEFAULT_BASE_API_URL = 'https://api.voxel51.com';
 const HELP_URL = 'https://voxel51.com/docs/api/?javascript#authentication';
 
 /**
@@ -121,6 +121,7 @@ function loadToken(tokenPath=null) {
   throw new TokenError('No API token found');
 }
 
+// eslint-disable-next-line require-jsdoc
 function loadTokenFromPath_(tokenPath) {
   if (!fs.existsSync(tokenPath)) {
     throw new TokenError(`No file found at '${tokenPath}'`);
@@ -194,7 +195,7 @@ class Token {
     return new Token({
       access_token: {
         private_key: privateKey,
-        base_api_url: baseAPIURL || DEAFULT_BASE_API_URL,
+        base_api_url: baseAPIURL || DEFAULT_BASE_API_URL,
       },
     });
   }
@@ -203,7 +204,7 @@ class Token {
   static parseBaseAPIURL_(accessToken) {
     let baseAPIURL = accessToken.base_api_url;
     if (!baseAPIURL) {
-      baseAPIURL = DEAFULT_BASE_API_URL;
+      baseAPIURL = DEFAULT_BASE_API_URL;
       console.warn(
         `No base API URL found in token; defaulting to '${baseAPIURL}'. To ` +
         `resolve this message, download a new API token from the Platform`);


### PR DESCRIPTION
Same functionality as https://github.com/voxel51/api-py/pull/81 for the JS client lib.

Now one can authenticate the API simply by setting `VOXEL51_API_PRIVATE_KEY`.