### PR TITLE
Adding method to get analytic ID by name + version

### DIFF
--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -16,6 +16,7 @@ const urljoin = require('url-join');
 const auth = require('./auth.js');
 const jobs = require('./jobs.js');
 const requests = require('./requests.js');
+const query = require('./query.js');
 const utils = require('./utils.js');
 
 const APIError = requests.APIError;
@@ -123,6 +124,44 @@ class API {
     let body = await requests.get(
       uri, this.header_, {qs: analyticsQuery.toObject()});
     return JSON.parse(body);
+  }
+
+  /**
+   * Gets the ID of the analytic with the given name (and optional version).
+   *
+   * Under the hood, this method uses an AnalyticsQuery to search for the
+   * analytic on the Platform. Thus, technically, `name` and `version` can be
+   * substrings of the full analytic name and version. However, this method
+   * raises an error if multiple analytics are found to match the search.
+   *
+   * @async
+   * @param {string} name - the name of the analytic
+   * @param {string} [version=undefined] - the analytic version. By default,
+   *   the latest version of the analytic is used
+   * @return {string} the ID of the analytic
+   * @throws {APIError} if the request was unsuccessful
+   */
+  async getAnalyticID(name, version=undefined) {
+    let analyticsQuery = new query.AnalyticsQuery();
+    analyticsQuery.addField('id');
+    analyticsQuery.addSearch('name', name);
+
+    if (version) {
+      analyticsQuery.addSearch('version', version);
+      analyticsQuery.setAllVersions(true);
+    }
+
+    let result = await this.queryAnalytics(analyticsQuery);
+    let analytics = result.analytics;
+
+    if (analytics.length != 1) {
+      let prettyName = renderPrettyAnalyticName_(name, version);
+      throw new Error(
+        `Expected one match for analytic '${prettyName}'; ` +
+        `found ${analytics.length}`);
+    }
+
+    return analytics[0].id;
   }
 
   /**
@@ -1000,6 +1039,11 @@ class API {
       uri, this.header_, {json: true, body: bodyData});
     return res.responses;
   }
+}
+
+// eslint-disable-next-line require-jsdoc
+function renderPrettyAnalyticName_(name, version=undefined) {
+  return version ? `${name} v${version}` : name;
 }
 
 // eslint-disable-next-line require-jsdoc

--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -129,15 +129,10 @@ class API {
   /**
    * Gets the ID of the analytic with the given name (and optional version).
    *
-   * Under the hood, this method uses an AnalyticsQuery to search for the
-   * analytic on the Platform. Thus, technically, `name` and `version` can be
-   * substrings of the full analytic name and version. However, this method
-   * raises an error if multiple analytics are found to match the search.
-   *
    * @async
    * @param {string} name - the name of the analytic
    * @param {string} [version=undefined] - the analytic version. By default,
-   *   the latest version of the analytic is used
+   *   the latest version of the analytic is returned
    * @return {string} the ID of the analytic
    * @throws {Error} if the specified analytic was not (uniquely) found
    */
@@ -152,15 +147,14 @@ class API {
     }
 
     let result = await this.queryAnalytics(analyticsQuery);
-    let analytics = result.analytics.filter((analytic) =>
-      analytic.name.toLowerCase() == name.toLowerCase() &&
-      (!version || analytic.version.toLowerCase() == version.toLowerCase()));
 
-    if (analytics.length != 1) {
+    // Queries match substrings, so we must enforce exact matching manually
+    let analytics = result.analytics.filter(
+      (a) => a.name == name && (!version || a.version == version));
+
+    if (!analytics.length) {
       let prettyName = renderPrettyAnalyticName_(name, version);
-      throw new Error(
-        `Expected one match for analytic '${prettyName}'; ` +
-        `found ${analytics.length}`);
+      throw new Error(`Analytic '${prettyName}' not found`);
     }
 
     return analytics[0].id;

--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -139,7 +139,7 @@ class API {
    * @param {string} [version=undefined] - the analytic version. By default,
    *   the latest version of the analytic is used
    * @return {string} the ID of the analytic
-   * @throws {APIError} if the request was unsuccessful
+   * @throws {Error} if the specified analytic was not (uniquely) found
    */
   async getAnalyticID(name, version=undefined) {
     let analyticsQuery = new query.AnalyticsQuery();

--- a/lib/users/api.js
+++ b/lib/users/api.js
@@ -143,7 +143,7 @@ class API {
    */
   async getAnalyticID(name, version=undefined) {
     let analyticsQuery = new query.AnalyticsQuery();
-    analyticsQuery.addField('id');
+    analyticsQuery.addFields(['id', 'name', 'version']);
     analyticsQuery.addSearch('name', name);
 
     if (version) {
@@ -152,7 +152,9 @@ class API {
     }
 
     let result = await this.queryAnalytics(analyticsQuery);
-    let analytics = result.analytics;
+    let analytics = result.analytics.filter((analytic) =>
+      analytic.name.toLowerCase() == name.toLowerCase() &&
+      (!version || analytic.version.toLowerCase() == version.toLowerCase()));
 
     if (analytics.length != 1) {
       let prettyName = renderPrettyAnalyticName_(name, version);

--- a/lib/users/query.js
+++ b/lib/users/query.js
@@ -12,8 +12,6 @@
 const autoBind = require('auto-bind');
 const qs = require('qs');
 
-const requests = require('./requests.js');
-
 /**
  * Base class for API queries.
  *
@@ -86,7 +84,7 @@ class BaseQuery {
    */
   addSearch(field, searchStr) {
     if (!this.isSupportedField_(field)) {
-      throw new requests.APIError('Invalid search parameter ' + field, 400);
+      throw new Error('Invalid search parameter ' + field);
     }
     this.search.push(`${field}:${searchStr}`);
     return this;

--- a/lib/users/query.js
+++ b/lib/users/query.js
@@ -83,9 +83,6 @@ class BaseQuery {
    * @return {BaseQuery} the updated query instance
    */
   addSearch(field, searchStr) {
-    if (!this.isSupportedField_(field)) {
-      throw new Error('Invalid search parameter ' + field);
-    }
     this.search.push(`${field}:${searchStr}`);
     return this;
   }


### PR DESCRIPTION
Users run analytics via their `name` and `version`, so looking up analytics in this way is also a common use case that we should support.

Note that I am just implementing this clientside for now.